### PR TITLE
Fixed k3s init script and update docs

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,10 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
 > - HTTPS access configuration is not supported yet, you can adjust the Nginx configuration in the container yourself.
 > - If`SERVER_DOMAIN`and`SERVER_PORT`are modified, it is recommended to delete the persistent data directory and recreate it.
 > - Cloud server`SERVER_DOMAIN = <external public ip>`
+>
+> **Note:**
+>
+> - Please make sure that your local IP address segment and the docker default address segment (172.17.0.0) do not overlap. If they overlap, please try changing the local network connection (for example, changing the Ethernet network).
 
 #### Quick Installation (Space and model inference & fine-tuning functions cannot be used)
 
@@ -47,6 +51,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - Quick start without data persistence volumes
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -55,7 +60,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 2222:2222 \
             -p 8000:8000 \
             -p 9000:9000 \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -63,6 +68,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - Normal startup with persistent data volumes
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -73,7 +79,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 9000:9000 \
             -v /srv/csghub/data:/var/opt \
             -v /srv/csghub/log:/var/log \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -103,6 +109,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - Quick start without data persistence volumes
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -111,7 +118,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 2222:2222 \
             -p 8000:8000 \
             -p 9000:9000 \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -119,6 +126,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - Normal startup with persistent data volumes
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -129,7 +137,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 9000:9000 \
             -v ~/Documents/csghub/data:/var/opt \
             -v ~/Documents/csghub/log:/var/log \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -148,6 +156,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - **Powershell**
     
         ```shell
+        $env:SERVER_DOMAIN = ((Get-NetAdapter -Physical | Get-NetIPAddress -AddressFamily IPv4)[0].IPAddress) 
         $env:SERVER_PORT = "80"
         docker run -it -d `
             --name omnibus-csghub `
@@ -156,7 +165,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 2222:2222 `
             -p 8000:8000 `
             -p 9000:9000 `
-            -e SERVER_DOMAIN="<your ip address>" `
+            -e SERVER_DOMAIN=$env:SERVER_DOMAIN `
             -e SERVER_PORT=$env:SERVER_PORT `
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -164,6 +173,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - **CMD**
     
         ```shell
+        set SERVER_DOMAIN=<your ip address>
         set SERVER_PORT=80
         docker run -it -d ^
             --name omnibus-csghub ^
@@ -172,7 +182,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -p 2222:2222 ^
             -p 8000:8000 ^
             -p 9000:9000 ^
-            -e SERVER_DOMAIN=<your ip address> ^
+            -e SERVER_DOMAIN=%SERVER_DOMAIN% ^
             -e SERVER_PORT=%SERVER_PORT% ^
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -216,6 +226,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - Install CSGHub
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -229,7 +240,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -v /srv/csghub/log:/var/log \
             -v ~/.kube:/etc/.kube \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -241,6 +252,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
     - **macOS**
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -254,7 +266,7 @@ Omnibus CSGHub is a way for OpenCSG to quickly deploy CSGHub using Docker, mainl
             -v ~/Documents/csghub/log:/var/log \
             -v ~/.kube:/etc/.kube \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```

--- a/docker/scripts/k3s-install.sh
+++ b/docker/scripts/k3s-install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -z "$SERVER_DOMAIN" ]; then
-  echo "env SERVER_DOMAIN ot set. it can be set as ip or domain."
+  echo "env SERVER_DOMAIN for csghub not set. it can be set as ip or domain."
   exit 1
 fi
 
@@ -505,7 +505,7 @@ fi
 
 if [ "$ENABLE_K3S" == "true" ]; then
   log "INFO" "Adding insecure registry to k3s."
-  REGISTRY_ADDRESS="$IP_ADDRESS:5000"
+  REGISTRY_ADDRESS="$SERVER_DOMAIN:5000"
   REGISTRY_USERNAME=registry
   REGISTRY_PASSWORD=registry
 

--- a/docs/zh/README_cn_docker.md
+++ b/docs/zh/README_cn_docker.md
@@ -25,11 +25,15 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
 
 ### 安装步骤
 
-> 提示：
+> **提示：**
 >
 > - HTTPS 访问配置暂时不支持，可自行调整容器内 Nginx 配置。
 > - 如果`SERVER_DOMAIN`和`SERVER_PORT`进行了修改，建议删除持久化数据目录后重新创建。
 > - 云服务器 `SERVER_DOMAIN = <external public ip>`
+>
+> **注意：**
+>
+> - 请确保你本地的IP地址段和docker默认的地址段（172.17.0.0）不重叠，如果重叠，请尝试更换本地网络连接（例如更换以太网网络）。
 
 #### 快速安装（无法使用 Space、模型推理微调功能）
 
@@ -46,6 +50,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - 快速启动（不做数据持久化）
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -54,7 +59,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 2222:2222 \
             -p 8000:8000 \
             -p 9000:9000 \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -62,6 +67,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - 正常启动（持久化数据）
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -72,7 +78,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 9000:9000 \
             -v /srv/csghub/data:/var/opt \
             -v /srv/csghub/log:/var/log \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -102,6 +108,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - 快速启动（不做数据持久化）
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -110,7 +117,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 2222:2222 \
             -p 8000:8000 \
             -p 9000:9000 \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -118,6 +125,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - 正常启动（持久化数据）
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -128,7 +136,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 9000:9000 \
             -v ~/Documents/csghub/data:/var/opt \
             -v ~/Documents/csghub/log:/var/log \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -146,6 +154,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - **Powershell**
 
         ```shell
+        $env:SERVER_DOMAIN = ((Get-NetAdapter -Physical | Get-NetIPAddress -AddressFamily IPv4)[0].IPAddress) 
         $env:SERVER_PORT = "80"
         docker run -it -d `
             --name omnibus-csghub `
@@ -154,14 +163,15 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 2222:2222 `
             -p 8000:8000 `
             -p 9000:9000 `
-            -e SERVER_DOMAIN="<your ip address>" `
+            -e SERVER_DOMAIN=$env:SERVER_DOMAIN `
             -e SERVER_PORT=$env:SERVER_PORT `
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
-
+    
     - **CMD**
-
+    
         ```shell
+        set SERVER_DOMAIN=<your ip address>
         set SERVER_PORT=80
         docker run -it -d ^
             --name omnibus-csghub ^
@@ -170,7 +180,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -p 2222:2222 ^
             -p 8000:8000 ^
             -p 9000:9000 ^
-            -e SERVER_DOMAIN=<your ip address> ^
+            -e SERVER_DOMAIN=%SERVER_DOMAIN% ^
             -e SERVER_PORT=%SERVER_PORT% ^
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -214,6 +224,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - 安装 CSGHub
 
         ```shell
+        export SERVER_DOMAIN=$(ip addr show $(ip route show default | awk '/default/ {print $5}') | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -227,7 +238,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -v /srv/csghub/log:/var/log \
             -v ~/.kube:/etc/.kube \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
@@ -239,6 +250,7 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
     - **macOS**
 
         ```shell
+        export SERVER_DOMAIN=$(ipconfig getifaddr $(route get default | grep interface | awk '{print $2}'))
         export SERVER_PORT=80
         docker run -it -d \
             --name omnibus-csghub \
@@ -252,13 +264,13 @@ Omnibus CSGHub 是 OpenCSG 推出的使用 Docker 快速部署 CSGHub 的一种�
             -v ~/Documents/csghub/log:/var/log \
             -v ~/.kube:/etc/.kube \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -e SERVER_DOMAIN=<your ip address> \
+            -e SERVER_DOMAIN=${SERVER_DOMAIN} \
             -e SERVER_PORT=${SERVER_PORT} \
             opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/omnibus-csghub:v1.0.0
         ```
-
+    
     - **Windows**
-
+    
         暂未支持。
 
 ### 访问 CSGHub


### PR DESCRIPTION
1. Update the Docker deployment docs and simplify the deployment steps
2. Fix the k3s init script pointing REGISTRY at the wrong value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced installation instructions for deploying CSGHub using Docker, including dynamic retrieval of local IP address for `SERVER_DOMAIN`.
	- Improved clarity in the installation steps across Linux, macOS, and Windows environments.

- **Bug Fixes**
	- Updated error messages in the installation script to clarify the necessity of the `SERVER_DOMAIN` variable.

- **Documentation**
	- Refined documentation with clearer headings, formatting adjustments, and a new note regarding IP address conflicts to improve user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
