### PR TITLE
Fix invalid 'restart' property in  depends_on

### DIFF
--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -4,13 +4,10 @@ services:
     depends_on:
       csghub-portal:
         condition: service_started
-        restart: true
       csghub-server:
         condition: service_healthy
-        restart: true
       casdoor:
         condition: service_healthy
-        restart: true
     ports:
       - "${SERVER_PORT:-80}:${SERVER_PORT:-80}"
       - "${GIT_SSH_PORT:-2222}:2222"
@@ -41,7 +38,6 @@ services:
         condition: service_healthy
     volumes:
       - ${CSGHUB_DATA_DIR:-"./data"}/redis:/data
-    restart: always
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 1s
@@ -253,10 +249,8 @@ services:
     depends_on:
       nats:
         condition: service_started
-        restart: true
       temporal:
         condition: service_healthy
-        restart: true
     environment:
       # Server
       GIN_MODE: release
@@ -638,7 +632,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-        restart: true
     environment:
       RUNNING_IN_DOCKER: true
     volumes:
@@ -663,7 +656,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-        restart: true
     environment:
       DB: "postgres12"
       POSTGRES_SEEDS: "$POSTGRES_HOST"


### PR DESCRIPTION
## Description
Fix the invalid `restart` property in the `depends_on` field (Docker Compose does not support it).

## Changes
- Remove `depends_on.postgres.restart: true`.

Related issue: https://github.com/OpenCSGs/csghub-installer/issues/206
