### PR TITLE
chore(casdoor): upgrade from v2.79.0 to v3.62.0

### DIFF
--- a/charts/csghub/templates/casdoor/configmap.yaml
+++ b/charts/csghub/templates/casdoor/configmap.yaml
@@ -50,7 +50,7 @@ data:
     logConfig = {"filename": "/dev/stdout", "maxdays":99999, "perm":"0770"}
     initDataFile = "/conf/init_data.json"
     initDataNewOnly = true
-    frontendBaseDir = "../casdoor"
+    frontendBaseDir = "../cc_0"
   init_data.json: |
     {
       "organizations": [

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -687,7 +687,7 @@ casdoor:
   image:
     # registry: "docker.io"
     repository: "casbin/casdoor"
-    tag: "v2.79.0"                           # Image version tag
+    tag: "3.62.0"                            # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 

--- a/charts/csgship/templates/casdoor/configmap.yaml
+++ b/charts/csgship/templates/casdoor/configmap.yaml
@@ -51,7 +51,7 @@ data:
     logConfig = {"filename": "/dev/stdout", "maxdays":99999, "perm":"0770"}
     initDataFile = "/conf/init_data.json"
     initDataNewOnly = true
-    frontendBaseDir = "../casdoor"
+    frontendBaseDir = "../cc_0"
   init_data.json: |
     {
       "organizations": [

--- a/charts/csgship/values.yaml
+++ b/charts/csgship/values.yaml
@@ -250,7 +250,7 @@ casdoor:
   image:
     # registry: "docker.io"
     repository: "casbin/casdoor"
-    tag: "v2.79.0"                           # Image version tag
+    tag: "3.62.0"                            # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 


### PR DESCRIPTION
## Changes

Upgrade Casdoor v2.79.0 -> v3.62.0

### Files

| File | Change |
|------|--------|
| charts/csghub/values.yaml | tag: `v2.79.0` -> `3.62.0` |
| charts/csgship/values.yaml | tag: `v2.79.0` -> `3.62.0` |
| charts/csghub/templates/casdoor/configmap.yaml | frontendBaseDir: `../casdoor` -> `../cc_0` |
| charts/csgship/templates/casdoor/configmap.yaml | frontendBaseDir: `../casdoor` -> `../cc_0` |

### Compatibility

- v3 changes frontendBaseDir to `../cc_0`; updated accordingly
- OAuth/OIDC protocol, API, and database schema are compatible
- The image tag has no `v` prefix (Docker Hub convention)
- Ref: infrade#134
