### PR TITLE
feat(aigateway): add useDomain parameter for dedicated domain exposure

### DIFF
--- a/charts/agentichub/templates/_agentichub.tpl
+++ b/charts/agentichub/templates/_agentichub.tpl
@@ -63,6 +63,24 @@ Returns: Unique API token string that changes on every installation
   {{- printf "%s%s" $namespaceHash $nameHash | sha256sum | trunc 32 | b64enc -}}
 {{- end -}}
 
+{{/*# Endpoint Helper
+# Resolves the aigateway URL based on configuration:
+# 1. If .Values.aigateway.endpoint is set → use it directly
+# 2. If isBuiltIn (bundled with csghub) → use csghub's common.endpoint.aigateway
+# 3. Otherwise → use <csghub-endpoint>/aigateway
+# Usage: {{ include "endpoint.aigateway" . }}
+*/}}
+{{- define "endpoint.aigateway" }}
+{{- $aigateway := .Values.aigateway | default dict }}
+{{- if $aigateway.endpoint }}
+{{- $aigateway.endpoint -}}
+{{- else if .Values.global.chartContext.isBuiltIn }}
+{{- include "common.endpoint.aigateway" . -}}
+{{- else }}
+{{- printf "%s/aigateway" (include "common.endpoint.csghub" .) -}}
+{{- end }}
+{{- end }}
+
 {{/*
 Generate global unique HUB_SERVER_API_TOKEN
 

--- a/charts/agentichub/templates/agenticflow/configmap.yaml
+++ b/charts/agentichub/templates/agenticflow/configmap.yaml
@@ -38,7 +38,7 @@ data:
   CSGHUB_INTERNAL_BASE_URL: {{ $csghubEndpoint | quote }}
   {{- end }}
   CSGHUB_API_BASE_URL: {{ $csghubEndpoint | quote }}
-  CSGHUB_AIGATEWAY_URL: {{ printf "%s/aigateway" $csghubEndpoint | quote }}
+  CSGHUB_AIGATEWAY_URL: {{ include "endpoint.aigateway" . | quote }}
 
   {{- $apiToken := .Values.hubAPIToken }}
   {{- if $isBuiltIn }}

--- a/charts/agentichub/templates/csgbot/configmap.yaml
+++ b/charts/agentichub/templates/csgbot/configmap.yaml
@@ -42,10 +42,10 @@ data:
     {{- end }}
     hub-base-url = {{ $csghubEndpoint | quote }}
     base-url = {{ $csghubEndpoint | quote }}
-    mcp-gateway-url = {{ printf "%s/aigateway/v1/gateway/mcp" $csghubEndpoint | quote }}
+    mcp-gateway-url = {{ printf "%s/v1/gateway/mcp" (include "endpoint.aigateway" .) | quote }}
 
     [aigateway]
-    base-url = {{ printf "%s/aigateway" $csghubEndpoint | quote }}
+    base-url = {{ include "endpoint.aigateway" . | quote }}
     model-id = {{ dig "config" "aigateway" "model" "deepseek-v3" .Values.csgbot | quote }}
 
     [langflow]
@@ -84,7 +84,7 @@ data:
 
     [csghub-sandbox]
     base-url = {{ $csghubEndpoint | quote }}
-    aigateway-url = {{ printf "%s/aigateway" $csghubEndpoint | quote }}
+    aigateway-url = {{ include "endpoint.aigateway" . | quote }}
 
     [openclaw-sandbox]
     image = {{ include "common.image" (list . (dig "config" "sandbox" "openclaw" "image" dict .Values.csgbot)) | quote }}

--- a/charts/agentichub/tests/aigateway_test.yaml
+++ b/charts/agentichub/tests/aigateway_test.yaml
@@ -1,0 +1,25 @@
+suite: Test AgenticHub Aigateway Endpoint (Standalone)
+templates:
+  - agenticflow/configmap.yaml
+release:
+  name: agentichub
+  namespace: agentichub
+set:
+  global:
+    chartContext:
+      isBuiltIn: false
+tests:
+  - it: Should use /aigateway sub-path by default (standalone, no url set)
+    asserts:
+      - equal:
+          path: data.CSGHUB_AIGATEWAY_URL
+          value: "http://csghub.example.com/aigateway"
+
+  - it: Should use explicit endpoint when aigateway.endpoint is set
+    set:
+      aigateway:
+        endpoint: "https://aigateway.example.com"
+    asserts:
+      - equal:
+          path: data.CSGHUB_AIGATEWAY_URL
+          value: "https://aigateway.example.com"

--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -34,6 +34,19 @@ global:
                                     # a subdomain (e.g. csghub.example.com) will be used internally
                                     # to avoid overly broad wildcard routing such as *.example.com
 
+      ## AIGateway domain configuration (only effective when bundled with csghub)
+      ## When deployed standalone, use aigateway.endpoint to specify the AIGateway URL directly.
+      ## Priority: domain > useDomain > default basePath
+      ## Examples:
+      ##   - domain: "" + useDomain: false → https://<domain>/aigateway (basePath)
+      ##   - domain: "" + useDomain: true  → https://aigateway.<base-domain> (auto domain)
+      ##   - domain: "ai.example.com"      → https://ai.example.com (custom domain, useDomain ignored)
+      aigateway:
+        useDomain: false            # Use dedicated domain for AIGateway (aigateway.<base-domain>)
+                                    # When false and domain is not set, AIGateway uses basePath mode.
+        # domain: ""                # Optional custom domain for AIGateway (e.g., "ai.example.com")
+                                    # If set, dedicated domain mode is always used regardless of useDomain.
+
       ## Whether to use the top-level domain directly when generating derived domains.
       ## If the domain is a multi-level domain (e.g. csghub.example.com):
       ## - true:  use the full domain as-is (casdoor.csghub.example.com)
@@ -96,6 +109,15 @@ externalUrl: "https://csghub.example.com"
 
 ## API token for authenticating with CSGHub API
 hubAPIToken: ""
+
+## AIGateway endpoint configuration
+## Priority: aigateway.endpoint > global.gateway.external.aigateway
+## - For standalone deployment: Set aigateway.endpoint directly
+## - For bundled deployment: Use global.gateway.external.aigateway (domain/useDomain)
+## - If aigateway.endpoint is set, it overrides all other configurations
+aigateway:
+  # endpoint: ""               # Full AIGateway URL (e.g., "https://ai.example.com")
+                               # When set, takes precedence over global.gateway.external.aigateway
 
 agenticflow:
   image:

--- a/charts/csghub/templates/csghub/_aigateway.tpl
+++ b/charts/csghub/templates/csghub/_aigateway.tpl
@@ -1,0 +1,42 @@
+{{- /*
+Copyright OpenCSG, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/ -}}
+
+{{/*
+# AI Gateway Domain Helper
+# Generates the full domain name for AIGateway service based on configuration
+# Usage: {{ include "common.domain.aigateway" . }}
+# Returns: aigateway.<base-domain>
+*/}}
+{{- define "common.domain.aigateway" -}}
+{{- $service := include "common.service" (dict "ctx" . "service" "aigateway") | fromYaml }}
+{{- include "common.domain" (dict "ctx" . "sub" $service.name) -}}
+{{- end }}
+
+{{/*
+# AI Gateway External Endpoint Helper
+# Generates the complete external access endpoint for AIGateway service
+# Usage: {{ include "common.endpoint.aigateway" . }}
+# Configuration (in global.gateway.external.aigateway):
+#   - domain: Custom domain (e.g., "ai.example.com") - takes precedence if set
+#   - useDomain: true to use dedicated domain (aigateway.<base-domain>)
+# Returns:
+#   - Custom domain set: Full URL to custom domain (http://ai.example.com)
+#   - useDomain=true:    Full URL to dedicated domain (http://aigateway.<domain>)
+#   - default:           Path-based URL under main domain (http://<csghub-domain>/aigateway)
+*/}}
+{{- define "common.endpoint.aigateway" }}
+{{- $external := .Values.global.gateway.external | default dict }}
+{{- $aigatewayConfig := $external.aigateway | default dict }}
+{{- $customDomain := $aigatewayConfig.domain | default "" }}
+{{- $useDomain := $aigatewayConfig.useDomain | default false }}
+
+{{- if $customDomain }}
+{{-   include "common.endpoint" (dict "ctx" . "domain" $customDomain) -}}
+{{- else if $useDomain }}
+{{-   include "common.endpoint" (dict "ctx" . "domain" (include "common.domain.aigateway" .)) -}}
+{{- else }}
+{{-   printf "%s/aigateway" (include "common.endpoint.csghub" .) -}}
+{{- end }}
+{{- end }}

--- a/charts/csghub/templates/csghub/aigateway/httproutes.yaml
+++ b/charts/csghub/templates/csghub/aigateway/httproutes.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Copyright OpenCSG, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/ -}}
+
+{{- $external := .Values.global.gateway.external | default dict }}
+{{- $aigatewayConfig := $external.aigateway | default dict }}
+{{- $useDomain := $aigatewayConfig.useDomain | default false }}
+{{- $customDomain := $aigatewayConfig.domain | default "" }}
+{{- if or $useDomain $customDomain }}
+{{- $service := include "common.service" (dict "ctx" . "service" "aigateway") | fromYaml }}
+{{- $serviceName := include "common.names.custom" (list . $service.name) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $serviceName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/service: {{ $service.name }}
+    {{- include "common.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: listeners
+      {{- if .Values.global.gateway.tls.enabled }}
+      sectionName: https
+      {{- else }}
+      sectionName: http
+      {{- end }}
+  hostnames:
+    {{- if $customDomain }}
+    - {{ $customDomain }}
+    {{- else }}
+    - {{ include "common.domain.aigateway" . }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ dig "service" "port" "8094" $service.aigateway }}
+      timeouts:
+        request: 5m
+{{- end }}

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -58,7 +58,7 @@ data:
   CSGHUB_PORTAL_REDIS_PASSWORD: {{ $portalRedisConfig.password | quote }}
   {{- end }}
   ## Portal Configuration for AIGateway
-  CSGHUB_PORTAL_AI_GATEWAY_HOST: {{ printf "%s/aigateway" (include "common.endpoint.csghub" .) | quote }}
+  CSGHUB_PORTAL_AI_GATEWAY_HOST: {{ include "common.endpoint.aigateway" . | quote }}
 
   ## Accounting Configuration
   {{- $accountingSvc := include "common.service" (dict "ctx" . "service" "accounting") | fromYaml }}

--- a/charts/csghub/templates/csghub/httproutes.yaml
+++ b/charts/csghub/templates/csghub/httproutes.yaml
@@ -161,6 +161,10 @@ spec:
     {{- end }}
     {{- $aiGatewaySvc := include "common.service" (dict "ctx" . "service" "aigateway") | fromYaml }}
     {{- $aiGatewaySvcName := include "common.names.custom" (list . $aiGatewaySvc.name) }}
+    {{- $external := .Values.global.gateway.external | default dict }}
+    {{- $aigatewayConfig := $external.aigateway | default dict }}
+    {{- $aigatewayUseDomain := or ($aigatewayConfig.useDomain | default false) ($aigatewayConfig.domain | default "") }}
+    {{- if not $aigatewayUseDomain }}
     - matches:
         - path:
             type: PathPrefix
@@ -191,3 +195,4 @@ spec:
           port: {{ dig "service" "port" "8094" $aiGatewaySvc.aigateway }}
       timeouts:
         request: 5m
+    {{- end }}

--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -156,6 +156,49 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_PROMETHEUS_API_ADDRESS
           value: "http://csghub-prometheus-server:80/api/v1/query"
+      - equal:
+          path: data.CSGHUB_PORTAL_AI_GATEWAY_HOST
+          value: "https://csghub.example.com/aigateway"
+
+  - it: Should render aigateway with independent domain when useDomain=true
+    template: csghub/configmap.yaml
+    set:
+      global:
+        gateway:
+          external:
+            aigateway:
+              useDomain: true
+    asserts:
+      - equal:
+          path: data.CSGHUB_PORTAL_AI_GATEWAY_HOST
+          value: "https://aigateway.example.com"
+
+  - it: Should render aigateway with custom domain when domain is set
+    template: csghub/configmap.yaml
+    set:
+      global:
+        gateway:
+          external:
+            aigateway:
+              domain: "ai.custom.com"
+    asserts:
+      - equal:
+          path: data.CSGHUB_PORTAL_AI_GATEWAY_HOST
+          value: "https://ai.custom.com"
+
+  - it: Custom domain should take precedence over useDomain
+    template: csghub/configmap.yaml
+    set:
+      global:
+        gateway:
+          external:
+            aigateway:
+              domain: "ai.custom.com"
+              useDomain: true
+    asserts:
+      - equal:
+          path: data.CSGHUB_PORTAL_AI_GATEWAY_HOST
+          value: "https://ai.custom.com"
 
   - it: Should render ConfigMap correctly
     template: csghub/configmap.yaml

--- a/charts/csghub/tests/gateway_test.yaml
+++ b/charts/csghub/tests/gateway_test.yaml
@@ -5,6 +5,7 @@ templates:
   - csghub/httproutes.yaml
   - csghub/httproutes-wildcard.yaml
   - csghub/httproutes-redirect.yaml
+  - csghub/aigateway/httproutes.yaml
 release:
   name: csghub
   namespace: csghub
@@ -374,3 +375,45 @@ tests:
       - equal:
           path: spec.provider.kubernetes.envoyDeployment
           value: {}
+
+  - it: Should NOT render aigateway HTTPRoute when useDomain=false (default)
+    template: csghub/aigateway/httproutes.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Should render aigateway HTTPRoute when useDomain=true
+    template: csghub/aigateway/httproutes.yaml
+    set:
+      global:
+        gateway:
+          external:
+            aigateway:
+              useDomain: true
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: "aigateway.example.cn"
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: "csghub-aigateway"
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8094
+
+  - it: Should render aigateway HTTPRoute with custom domain
+    template: csghub/aigateway/httproutes.yaml
+    set:
+      global:
+        gateway:
+          external:
+            aigateway:
+              domain: "ai.custom.com"
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: "ai.custom.com"

--- a/charts/csghub/values.schema.json
+++ b/charts/csghub/values.schema.json
@@ -27,7 +27,14 @@
               "type": "object",
               "properties": {
                 "domain": {"type": "string"},
-                "public": {"type": "string"}
+                "public": {"type": "string"},
+                "aigateway": {
+                  "type": "object",
+                  "properties": {
+                    "useDomain": {"type": "boolean"},
+                    "domain": {"type": "string"}
+                  }
+                }
               }
             },
             "tls": {
@@ -157,7 +164,6 @@
     "gateway": {
       "type": "object",
       "properties": {
-        "aigateway": {"type": "object", "additionalProperties": true},
         "moderation": {"type": "object", "additionalProperties": true}
       }
     },

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -34,6 +34,19 @@ global:
                                      # a subdomain (e.g. csghub.example.com) will be used internally
                                      # to avoid overly broad wildcard routing such as *.example.com
 
+      ## AIGateway domain configuration (only effective when agentichub is bundled)
+      ## When agentichub is deployed standalone, use aigateway.endpoint to specify the URL directly.
+      ## Priority: domain > useDomain > default basePath
+      ## Examples:
+      ##   - domain: "" + useDomain: false → https://<domain>/aigateway (basePath)
+      ##   - domain: "" + useDomain: true  → https://aigateway.<base-domain> (auto domain)
+      ##   - domain: "ai.example.com"      → https://ai.example.com (custom domain, useDomain ignored)
+      aigateway:
+        useDomain: false             # Use dedicated domain for AIGateway (aigateway.<base-domain>)
+                                     # When false and domain is not set, AIGateway uses basePath mode.
+        # domain: ""                 # Optional custom domain for AIGateway (e.g., "ai.example.com")
+                                     # If set, dedicated domain mode is always used regardless of useDomain.
+
       ## Whether to use the top-level domain directly when generating derived domains.
       ## If the domain is a multi-level domain (e.g. csghub.example.com):
       ## - true:  use the full domain as-is (casdoor.csghub.example.com)
@@ -448,6 +461,12 @@ csgship:
 
 agentichub:
   enabled: true
+
+  ## AIGateway endpoint configuration (for standalone agentichub deployment)
+  ## When bundled with csghub, use global.gateway.external.aigateway instead.
+  ## Priority: aigateway.endpoint > global.gateway.external.aigateway
+  aigateway: {}
+    # endpoint: ""             # Full AIGateway URL, overrides global.gateway.external.aigateway if set
 
   ## Disable subCharts same with parent
   postgresql:


### PR DESCRIPTION
### Summary

Adds dedicated-domain exposure for the CSGHub AIGateway (`aigateway.aigateway.useDomain`), and simplifies the agentichub subchart's AIGateway endpoint logic to an explicit endpoint parameter, removing its dependency on the parent template.

### Files

| File | Op | Note |
|------|------|------|
| `charts/csghub/values.yaml` | modify | add `aigateway.aigateway.useDomain: false` |
| `charts/csghub/values.schema.json` | modify | add `useDomain: boolean` JSON Schema |
| `charts/csghub/templates/csghub/_aigateway.tpl` | add | `common.domain.aigateway` / `common.endpoint.aigateway` helpers |
| `charts/csghub/templates/csghub/aigateway/httproutes.yaml` | add | dedicated-domain HTTPRoute (rendered when `useDomain=true`) |
| `charts/csghub/templates/csghub/httproutes.yaml` | modify | conditional `/aigateway` path route (when `useDomain=false`) |
| `charts/csghub/templates/csghub/configmap.yaml` | modify | `CSGHUB_PORTAL_AI_GATEWAY_HOST` computed via `common.endpoint.aigateway` |
| `charts/csghub/tests/configmap_test.yaml` | modify | add useDomain test cases |
| `charts/csghub/tests/gateway_test.yaml` | modify | add HTTPRoute conditional rendering tests |
| `charts/agentichub/values.yaml` | modify | `aigateway: {}` accepts an explicit `endpoint` parameter |
| `charts/agentichub/templates/_agentichub.tpl` | modify | new `endpoint.aigateway` helper (2-level fallback: explicit endpoint -> `/aigateway` subpath) |
| `charts/agentichub/templates/csgbot/configmap.yaml` | modify | replace `common.endpoint.aigateway` -> `endpoint.aigateway` |
| `charts/agentichub/templates/agenticflow/configmap.yaml` | modify | same as above |
| `charts/agentichub/tests/aigateway_test.yaml` | add | agentichub endpoint fallback tests |

### Design

**Parent chart (csghub):**
- `aigateway.aigateway.useDomain: false` (default) -> reachable via the main domain's `/aigateway` path
- `aigateway.aigateway.useDomain: true` -> reachable via the dedicated domain `aigateway.<base-domain>`, and the path route is removed

**Subchart (agentichub):**
- Unaware of `useDomain`; only accepts an explicit `aigateway.endpoint` parameter
- 2-level fallback:
  1. `aigateway.endpoint` non-empty -> use it directly
  2. otherwise -> `<csghub-endpoint>/aigateway`
- Removes the previous `isBuiltIn` special branch (because of Helm's subchart value isolation, that branch called the parent template and caused a nil pointer)

### Verification

```
# useDomain: false (default)
CSGHUB_PORTAL_AI_GATEWAY_HOST: http://csghub.example.com/aigateway
/aigateway path route OK

# useDomain: true
CSGHUB_PORTAL_AI_GATEWAY_HOST: http://aigateway.example.com
dedicated-domain HTTPRoute rendered OK
/aigateway path route removed OK

# agentichub standalone (no explicit endpoint)
CSGHUB_AIGATEWAY_URL: http://csghub.example.com/aigateway

# agentichub custom endpoint
CSGHUB_AIGATEWAY_URL: https://my-aigateway.example.com

# agentichub isBuiltIn (bundled deployment)
CSGHUB_AIGATEWAY_URL: http://csghub.example.com/aigateway
```

### Unit tests

- csghub: 4 configmap cases + 12 gateway cases OK
- agentichub: 2 endpoint fallback cases OK
