### PR TITLE
fix: move basicAuth to correct spec level

### DIFF
--- a/charts/csghub/templates/loki/securitypolicy.yaml
+++ b/charts/csghub/templates/loki/securitypolicy.yaml
@@ -23,9 +23,9 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ $serviceName }}
-    basicAuth:
-      users:
-        name: {{ $serviceName }}
-        namespace: {{ .Release.Namespace }}
-      forwardUsernameHeader: "X-Forwarded-User"
+  basicAuth:
+    users:
+      name: {{ $serviceName }}
+      namespace: {{ .Release.Namespace }}
+    forwardUsernameHeader: "X-Forwarded-User"
 {{- end }}


### PR DESCRIPTION
## Summary

The `basicAuth` field belongs at the `spec` level in the SecurityPolicy CRD, alongside `targetRef`. It was incorrectly nested under `spec.targetRef.basicAuth`, which errored when `loki.gateway.enabled=true`:

```
.spec.targetRef.basicAuth: field not declared in schema
```

## Changes

- `charts/csghub/templates/loki/securitypolicy.yaml`: move `basicAuth` from a `targetRef` child field to the `spec` level

## Test plan

- [x] helm template renders correctly
- [x] helm unittest all pass
