### PR TITLE
chore: bump runner/dataflow/csghub charts to v2.4.0

### DIFF
--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,10 +16,10 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.3.0
+  version: 2.4.0
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
-  version: 2.3.1
+  version: 2.4.0
 - name: csgship
   repository: https://charts.opencsg.com/csghub
   version: 0.4.3
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:fe63c8e165f09559fa7879c49e6b1f71f132aa4a0f29a4d26843dbfa21a41d0f
-generated: "2026-07-31T18:38:59.126192+08:00"
+digest: sha256:561976883e2c32f8fa5f53c9218422ad2f7ec0dd31e755975b6912ca75b0daac
+generated: "2026-08-11T10:00:00+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,13 +22,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.2
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.3.0
+appVersion: v2.4.0
 
 # Defined dependencies for subChart
 dependencies:
@@ -52,11 +52,11 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.3.0
+    version: 2.4.0
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow
-    version: 2.3.1
+    version: 2.4.0
     repository: https://charts.opencsg.com/csghub
     condition: dataflow.enabled
   - name: csgship

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -64,7 +64,7 @@ global:
   image:
     registry: "docker.io"           # Image global registry, opencsg-registry.cn-beijing.cr.aliyuncs.com for mainland
     registryPolicy: "default"       # default or force, force will overwrite all others registries
-    tag: "v2.3.0"                   # Image tag format: {{version}}-{{edition}}
+    tag: "v2.4.0"                   # Image tag format: {{version}}-{{edition}}
     pullPolicy: "IfNotPresent"      # Image pull policy: Always, IfNotPresent, Never
     pullSecrets: []                 # Private registry authentication secrets
 
@@ -156,7 +156,7 @@ global:
 image:
   # registry: "docker.io"
   repository: "opencsghq/csghub-server"
-  tag: "v2.3.0"
+  tag: "v2.4.0"
   pullPolicy: "IfNotPresent"
   pullSecrets: []
 
@@ -392,7 +392,7 @@ xnet:
   image:
     # registry: "docker.io"
     repository: "opencsghq/csghub-xnet"
-    tag: "v2.3.0-ee"
+    tag: "v2.4.0-ee"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
 

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -22,13 +22,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.1
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.3.1
+appVersion: v2.4.0
 
 # Defined dependencies for subChart
 dependencies:

--- a/charts/dataflow/values.yaml
+++ b/charts/dataflow/values.yaml
@@ -48,7 +48,7 @@ global:
   image:
     registry: "docker.io"           # Image global registry, opencsg-registry.cn-beijing.cr.aliyuncs.com for mainland
     registryPolicy: "default"       # default or force, force will overwrite all others registries
-    tag: "v2.3.1"                   # Image tag format: {{version}}-{{edition}}
+    tag: "v2.4.0"                   # Image tag format: {{version}}-{{edition}}
     pullPolicy: "IfNotPresent"      # Image pull policy: Always, IfNotPresent, Never
     pullSecrets: []                 # Private registry authentication secrets
 
@@ -87,7 +87,7 @@ dataflow:
   image:
     # registry: "docker.io"
     repository: "opencsghq/dataflow"
-    tag: "v2.3.1-api"                       # Image version tag
+    tag: "v2.4.0-api"                       # Image version tag
     pullPolicy: "IfNotPresent"              # Image pull policy
     pullSecrets: []                         # Docker registry secrets
 
@@ -123,7 +123,7 @@ labelStudio:
   image:
     # registry: "docker.io"
     repository: "opencsghq/label-studio"
-    tag: "v2.3.1"                            # Image version tag
+    tag: "v2.4.0"                            # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,13 +25,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.0
+version: 2.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.3.0
+appVersion: v2.4.0
 
 # Defined dependencies for subChart
 dependencies:

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -48,7 +48,7 @@ global:
   image:
     registry: "docker.io"           # Image global registry, opencsg-registry.cn-beijing.cr.aliyuncs.com for mainland
     registryPolicy: "default"       # default or force, force will overwrite all others registries
-    tag: "v2.3.0"                   # Image tag format: {{version}}-{{edition}}
+    tag: "v2.4.0"                   # Image tag format: {{version}}-{{edition}}
     pullPolicy: "IfNotPresent"      # Image pull policy: Always, IfNotPresent, Never
     pullSecrets: []                 # Private registry authentication secrets
 
@@ -74,7 +74,7 @@ externalUrl: "https://csghub.example.com"
 image:
   # registry: "docker.io"                    # Docker registry
   repository: "opencsghq/csghub-server"
-  tag: "v2.3.0"                            # Image version tag
+  tag: "v2.4.0"                            # Image version tag
   pullPolicy: "IfNotPresent"               # Image pull policy: Always, IfNotPresent, Never
   pullSecrets: []                          # Docker registry secrets
 


### PR DESCRIPTION
## Changes

Upgrades the runner, dataflow, and csghub charts from v2.3.x to v2.4.0.

### charts/runner -> 2.4.0
- `Chart.yaml`: version `2.3.0` -> `2.4.0`, appVersion `v2.3.0` -> `v2.4.0`
- `values.yaml`: `global.image.tag`, `image.tag` -> `v2.4.0`

### charts/dataflow -> 2.4.0
- `Chart.yaml`: version `2.3.1` -> `2.4.0`, appVersion `v2.3.1` -> `v2.4.0`
- `values.yaml`: `global.image.tag` -> `v2.4.0`, `dataflow.image.tag` -> `v2.4.0-api`, `labelStudio.image.tag` -> `v2.4.0`

### charts/csghub -> 2.4.0
- `Chart.yaml`: version `2.3.2` -> `2.4.0`, appVersion `v2.3.0` -> `v2.4.0`
- `Chart.lock`: dependencies runner/dataflow -> `2.4.0`, digest synced
- `values.yaml`: `global.image.tag` -> `v2.4.0`, `image.tag` (csghub-server) -> `v2.4.0`, `xnet.image.tag` -> `v2.4.0-ee`

## Verification
- `helm lint` passes for all three charts
- `helm dependency update` resolves the 2.4.0 dependencies
- Render confirms the core images point at v2.4.0
