### PR TITLE
chore: bump csghub,agentichub,dataflow,runner,csgship versions

### DIFF
--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.7
+version: 0.6.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,13 +16,13 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.4.0
+  version: 2.4.1
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
-  version: 2.4.0
+  version: 2.4.1
 - name: csgship
   repository: https://charts.opencsg.com/csghub
-  version: 0.4.3
+  version: 0.4.4
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
@@ -31,9 +31,9 @@ dependencies:
   version: 1.7.5
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
-  version: 0.6.7
+  version: 0.6.8
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:ff067d9e5df2f99fd5cfa61b0214040afaecdfea4925441b6c391c5aeed7a796
-generated: "2026-08-14T12:59:10.865222+08:00"
+digest: sha256:4bd90c4d17dff5e3c3a2c6526619da2dde1f6eda8c060fded5a0f6304ca498ed
+generated: "2026-08-17T17:56:39.135958+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -52,15 +52,15 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.4.0
+    version: 2.4.1
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow
-    version: 2.4.0
+    version: 2.4.1
     repository: https://charts.opencsg.com/csghub
     condition: dataflow.enabled
   - name: csgship
-    version: 0.4.3
+    version: 0.4.4
     repository: https://charts.opencsg.com/csghub
     condition: csgship.enabled
   - name: memmachine
@@ -73,7 +73,7 @@ dependencies:
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
   - name: agentichub
-    version: 0.6.7
+    version: 0.6.8
     repository: https://charts.opencsg.com/csghub
     condition: agentichub.enabled
   - name: superset

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary

Version bump to follow up the fixes in PR #710:

| Chart | Before | After |
|---|---|---|
| agentichub | 0.6.7 | 0.6.8 |
| runner | 2.4.0 | 2.4.1 |
| dataflow | 2.4.0 | 2.4.1 |
| csgship | 0.4.3 | 0.4.4 |

## Changes

- `charts/agentichub/Chart.yaml`, `charts/runner/Chart.yaml`, `charts/dataflow/Chart.yaml`, `charts/csgship/Chart.yaml`: bump `version`
- `charts/csghub/Chart.yaml`: sync the four sub-dependency versions (runner/dataflow/csgship/agentichub)
- `charts/csghub/Chart.lock`: dependency versions + digest + generated timestamp

## Notes

- csghub's own `version` stays `2.4.0` (no csghub template change here); let me know if it should be bumped
- Ready to release once PR #710 is merged
