### PR TITLE
feat: schema validation for all charts

### DIFF
--- a/charts/agentichub/values.schema.json
+++ b/charts/agentichub/values.schema.json
@@ -1,0 +1,426 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "CSGHub Agentichub Values Schema",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global Configuration",
+      "properties": {
+        "edition": {
+          "type": "string",
+          "enum": ["ce", "ee", "saas"],
+          "description": "Deployment edition"
+        },
+        "gateway": {
+          "type": "object",
+          "description": "Gateway API configuration",
+          "properties": {
+            "controllerName": { "type": "string", "description": "GatewayClass controller name" },
+            "service": {
+              "type": "object",
+              "description": "Gateway Service configuration",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["LoadBalancer", "NodePort", "ClusterIP"]
+                },
+                "nodePorts": {
+                  "type": "object",
+                  "properties": {
+                    "http": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                    "https": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                    "gitssh": { "type": "integer", "minimum": 1, "maximum": 65535 }
+                  }
+                }
+              }
+            },
+            "external": {
+              "type": "object",
+              "description": "External domain configuration",
+              "properties": {
+                "domain": { "type": "string" },
+                "public": { "type": "string" },
+                "useTop": { "type": "boolean" },
+                "aigateway": {
+                  "type": "object",
+                  "properties": {
+                    "useDomain": { "type": "boolean" },
+                    "domain": { "type": "string" }
+                  }
+                }
+              }
+            },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "secretName": { "type": "string" }
+              }
+            }
+          }
+        },
+        "image": {
+          "type": "object",
+          "description": "Image management",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "registryPolicy": { "type": "string", "enum": ["default", "force"] },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "postgresql": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "external": {
+              "type": "object",
+              "properties": {
+                "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "user": { "type": "string" },
+                "password": { "type": "string" },
+                "timezone": { "type": "string" },
+                "sslmode": { "type": "string" },
+                "database": { "type": "string" }
+              }
+            }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "external": {
+              "type": "object",
+              "properties": {
+                "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                "password": { "type": "string" }
+              }
+            }
+          }
+        },
+        "chartContext": {
+          "type": "object",
+          "properties": {
+            "isBuiltIn": { "type": "boolean", "description": "Deployed bundled with csghub" }
+          }
+        }
+      }
+    },
+    "externalUrl": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL. Optional when global.chartContext.isBuiltIn=true." }
+      ]
+    },
+    "hubAPIToken": { "type": "string", "description": "API token for CSGHub API" },
+    "aigateway": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "description": "AIGateway endpoint configuration",
+          "properties": {
+            "endpoint": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "agenticflow": {
+      "type": "object",
+      "description": "AgenticFlow service configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "workers": { "type": "integer", "minimum": 1, "description": "Number of Langflow workers" },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "postgresql": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "database": { "type": "string" },
+            "user": { "type": "string" },
+            "password": { "type": "string" },
+            "timezone": { "type": "string" },
+            "sslmode": { "type": "string" }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "properties": {
+            "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$" },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "password": { "type": "string" }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": { "type": "object" },
+            "limits": { "type": "object" }
+          }
+        }
+      }
+    },
+    "csgbot": {
+      "type": "object",
+      "description": "CSGBot configuration",
+      "properties": {
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+          }
+        },
+        "environments": { "type": "object" },
+        "config": {
+          "type": "object",
+          "properties": {
+            "aigateway": {
+              "type": "object",
+              "properties": {
+                "model": { "type": "string" },
+                "temperature": { "type": "number", "minimum": 0, "maximum": 2 }
+              }
+            },
+            "starship": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" }
+              }
+            },
+            "speechToText": {
+              "type": "object",
+              "properties": {
+                "modelId": { "type": "string" },
+                "apiMode": { "type": "string" },
+                "prompt": { "type": "string" },
+                "responseFormat": { "type": "string" },
+                "maxFileBytes": { "type": "string" },
+                "forwardTimeoutSeconds": { "type": "number" }
+              }
+            },
+            "integrations": { "type": "object" },
+            "fileServer": {
+              "type": "object",
+              "properties": {
+                "endpoint": { "type": "string" }
+              }
+            },
+            "sandbox": {
+              "type": "object",
+              "properties": {
+                "timeoutSeconds": { "type": "integer", "minimum": 0 },
+                "maxUploadFileBytes": { "type": "integer", "minimum": 0 },
+                "genius": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+                        "repository": { "type": "string" },
+                        "tag": { "type": "string" }
+                      }
+                    }
+                  }
+                },
+                "doc": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+                        "repository": { "type": "string" },
+                        "tag": { "type": "string" }
+                      }
+                    }
+                  }
+                },
+                "openclaw": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+                        "repository": { "type": "string" },
+                        "tag": { "type": "string" }
+                      }
+                    }
+                  }
+                },
+                "csgclawServer": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+                        "repository": { "type": "string" },
+                        "tag": { "type": "string" }
+                      }
+                    }
+                  }
+                },
+                "csgclawAgent": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "properties": {
+                        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+                        "repository": { "type": "string" },
+                        "tag": { "type": "string" }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "logging": { "type": "object" },
+            "observability": { "type": "object" },
+            "userFacingErrors": { "type": "object" }
+          }
+        }
+      }
+    },
+    "postgresql": {
+      "type": "object",
+      "description": "Built-in PostgreSQL configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "protocol": { "type": "string" }
+          }
+        },
+        "databases": { "type": "array", "items": { "type": "string" } },
+        "parameters": { "type": "object" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        }
+      }
+    },
+    "redis": {
+      "type": "object",
+      "description": "Built-in Redis configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "protocol": { "type": "string" }
+          }
+        },
+        "requirePass": { "type": "boolean" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "storageClass": { "type": "string" },
+            "accessModes": { "type": "array", "items": { "type": "string" } },
+            "size": { "type": "string" }
+          }
+        }
+      }
+    },
+    "reloader": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" }
+          }
+        }
+      }
+    },
+    "memmachine": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/charts/csghub/values.schema.json
+++ b/charts/csghub/values.schema.json
@@ -9,18 +9,30 @@
       "properties": {
         "edition": {
           "type": "string",
-          "description": "Deployment edition: \"ce\" (Community) or \"ee\" (Enterprise)"
+          "enum": ["ce", "ee", "saas"],
+          "description": "Deployment edition"
         },
         "gateway": {
           "type": "object",
           "description": "Gateway configuration",
           "properties": {
-            "controllerName": {"type": "string"},
+            "controllerName": { "type": "string" },
             "service": {
               "type": "object",
               "properties": {
-                "type": {"type": "string"},
-                "nodePorts": {"type": "object", "additionalProperties": {"type": "integer"}}
+                "type": {
+                  "type": "string",
+                  "enum": ["LoadBalancer", "NodePort", "ClusterIP"]
+                },
+                "nodePorts": {
+                  "type": "object",
+                  "additionalProperties": { "type": "integer" },
+                  "properties": {
+                    "http": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                    "https": { "type": "integer", "minimum": 1, "maximum": 65535 },
+                    "gitssh": { "type": "integer", "minimum": 1, "maximum": 65535 }
+                  }
+                }
               }
             },
             "external": {
@@ -49,11 +61,11 @@
         "image": {
           "type": "object",
           "properties": {
-            "registry": {"type": "string"},
-            "registryPolicy": {"type": "string"},
-            "tag": {"type": "string"},
-            "pullPolicy": {"type": "string"},
-            "pullSecrets": {"type": "array", "items": {"type": "string"}}
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "registryPolicy": { "type": "string", "enum": ["default", "force"] },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+            "pullSecrets": { "type": "array", "items": { "type": "string" } }
           }
         },
         "persistence": {
@@ -117,11 +129,11 @@
     "image": {
       "type": "object",
       "properties": {
-        "registry": {"type": "string"},
-        "repository": {"type": "string"},
-        "tag": {"type": "string"},
-        "pullPolicy": {"type": "string"},
-        "pullSecrets": {"type": "array", "items": {"type": "string"}}
+        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "pullSecrets": { "type": "array", "items": { "type": "string" } }
       }
     },
     "logging": {"type": "object", "additionalProperties": true},
@@ -139,32 +151,28 @@
     "server": {
       "type": "object",
       "properties": {
-        "image": {"type": "object", "additionalProperties": true},
-        "gitlabShell": {"type": "object", "additionalProperties": true},
-        "multiSync": {"type": "object", "additionalProperties": true},
-        "swaggerAPI": {"type": "object", "additionalProperties": true},
-        "agent": {"type": "object", "additionalProperties": true},
-        "csgbot": {"type": "object", "additionalProperties": true},
-        "memory": {"type": "object", "additionalProperties": true},
-        "postgresql": {"type": "object", "additionalProperties": true},
-        "redis": {"type": "object", "additionalProperties": true},
-        "objectStore": {"type": "object", "additionalProperties": true},
-        "xnet": {"type": "object", "additionalProperties": true}
+        "image": { "type": "object", "additionalProperties": true },
+        "postgresql": { "type": "object", "additionalProperties": true },
+        "redis": { "type": "object", "additionalProperties": true },
+        "xnet": { "type": "object", "additionalProperties": true }
       }
     },
     "rproxy": {
       "type": "object",
       "properties": {
-        "coredns": {"type": "object", "additionalProperties": true},
-        "nginx": {"type": "object", "additionalProperties": true}
+        "coredns": { "type": "object", "additionalProperties": true },
+        "nginx": { "type": "object", "additionalProperties": true }
       }
     },
-    "notifier": {"type": "object", "additionalProperties": true},
-    "payment": {"type": "object", "additionalProperties": true},
-    "gateway": {
+    "notifier": { "type": "object", "additionalProperties": true },
+    "payment": { "type": "object", "additionalProperties": true },
+    "aigateway": {
       "type": "object",
       "properties": {
-        "moderation": {"type": "object", "additionalProperties": true}
+        "image": { "type": "object", "additionalProperties": true },
+        "service": { "type": "object", "additionalProperties": true },
+        "moderation": { "type": "object", "additionalProperties": true },
+        "llm": { "type": "object", "additionalProperties": true }
       }
     },
     "xnet": {
@@ -186,9 +194,12 @@
           "type": "object",
           "properties": {
             "region": {"type": "string"},
-            "interval": {"type": "integer"},
+            "interval": { "type": "integer", "minimum": 1 },
             "namespace": {"type": "string"},
-            "mergingNamespace": {"type": "string"},
+            "mergingNamespace": {
+              "type": "string",
+              "enum": ["multi", "single", "disable"]
+            },
             "applicationEndpoint": {"type": "string"},
             "networkInterface": {"type": "string"},
             "storageClassName": {"type": "string"}

--- a/charts/csgship/values.schema.json
+++ b/charts/csgship/values.schema.json
@@ -31,7 +31,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["LoadBalancer", "NodePort"],
+                  "enum": ["LoadBalancer", "NodePort", "ClusterIP"],
                   "description": "Service type for Gateway"
                 }
               }
@@ -50,9 +50,10 @@
           "type": "object",
           "description": "Image management",
           "properties": {
-            "registry": { "type": "string", "description": "Custom image registry (overrides local registry)" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "Custom image registry (overrides local registry)" },
+            "registryPolicy": { "type": "string", "enum": ["default", "force"], "description": "Registry policy" },
             "tag": { "type": "string", "description": "Image tag format: {{version}}-{{edition}}" },
-            "pullPolicy": { "type": "string", "description": "Image pull policy: Always, IfNotPresent, Never" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy" },
             "pullSecrets": { "type": "array", "items": { "type": "string" }, "description": "Private registry authentication secrets" }
           }
         },
@@ -74,12 +75,13 @@
               "type": "object",
               "description": "External PostgreSQL connection",
               "properties": {
-                "host": { "type": "string", "description": "PostgreSQL host address" },
-                "port": { "type": "integer", "description": "PostgreSQL port" },
+                "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$", "description": "PostgreSQL host address" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "PostgreSQL port" },
                 "user": { "type": "string", "description": "Database username" },
                 "password": { "type": "string", "description": "Database password" },
                 "timezone": { "type": "string", "description": "Database timezone" },
-                "sslmode": { "type": "string", "description": "SSL mode" }
+                "sslmode": { "type": "string", "description": "SSL mode" },
+                "database": { "type": "string", "description": "Database name" }
               }
             }
           }
@@ -93,8 +95,8 @@
               "type": "object",
               "description": "External Redis configuration",
               "properties": {
-                "host": { "type": "string", "description": "Redis server hostname or IP" },
-                "port": { "type": "integer", "description": "Redis port number" },
+                "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$", "description": "Redis server hostname or IP" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "Redis port number" },
                 "password": { "type": "string", "description": "Redis authentication password" }
               }
             }
@@ -109,7 +111,12 @@
         }
       }
     },
-    "externalUrl": { "type": "string", "description": "External CSGHub URL for accessing the hub interface" },
+    "externalUrl": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL for accessing the hub interface. Optional when global.chartContext.isBuiltIn=true." }
+      ]
+    },
     "gateway": {
       "type": "object",
       "description": "Gateway API enablement",
@@ -132,10 +139,10 @@
       "type": "object",
       "description": "Global image configuration",
       "properties": {
-        "registry": { "type": "string", "description": "Docker registry" },
+        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "Docker registry" },
         "repository": { "type": "string", "description": "Image repository" },
         "tag": { "type": "string", "description": "Image version tag" },
-        "pullPolicy": { "type": "string", "description": "Image pull policy: Always, IfNotPresent, Never" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"], "description": "Image pull policy" },
         "pullSecrets": { "type": "array", "items": { "type": "string" }, "description": "Docker registry secrets" }
       }
     },
@@ -238,18 +245,18 @@
         "image": {
           "type": "object",
           "properties": {
-            "registry": { "type": "string" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
             "repository": { "type": "string" },
             "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
             "pullSecrets": { "type": "array", "items": { "type": "string" } }
           }
         },
         "service": {
           "type": "object",
           "properties": {
-            "type": { "type": "string" },
-            "port": { "type": "integer" },
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
             "protocol": { "type": "string" }
           }
         },
@@ -264,18 +271,18 @@
         "image": {
           "type": "object",
           "properties": {
-            "registry": { "type": "string" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
             "repository": { "type": "string" },
             "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
             "pullSecrets": { "type": "array", "items": { "type": "string" } }
           }
         },
         "service": {
           "type": "object",
           "properties": {
-            "type": { "type": "string" },
-            "port": { "type": "integer" },
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
             "protocol": { "type": "string" }
           }
         },
@@ -290,18 +297,18 @@
         "image": {
           "type": "object",
           "properties": {
-            "registry": { "type": "string" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
             "repository": { "type": "string" },
             "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
             "pullSecrets": { "type": "array", "items": { "type": "string" } }
           }
         },
         "service": {
           "type": "object",
           "properties": {
-            "type": { "type": "string" },
-            "port": { "type": "integer" },
+            "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
             "protocol": { "type": "string" }
           }
         },

--- a/charts/dataflow/values.schema.json
+++ b/charts/dataflow/values.schema.json
@@ -54,7 +54,7 @@
           "type": "object",
           "description": "Image management",
           "properties": {
-            "registry": { "type": "string", "description": "Custom image registry (overrides local registry)" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "Custom image registry (overrides local registry)" },
             "tag": { "type": "string", "description": "Image tag format: {{version}}-{{edition}}" },
             "pullPolicy": { "type": "string", "description": "Image pull policy: Always, IfNotPresent, Never" },
             "pullSecrets": { "type": "array", "description": "Private registry authentication secrets", "items": { "type": "string" } }
@@ -78,12 +78,13 @@
               "type": "object",
               "description": "External PostgreSQL connection",
               "properties": {
-                "host": { "type": "string", "description": "PostgreSQL host address" },
-                "port": { "type": "integer", "description": "PostgreSQL port" },
+                "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$", "description": "PostgreSQL host address" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "PostgreSQL port" },
                 "user": { "type": "string", "description": "Database username" },
                 "password": { "type": "string", "description": "Database password" },
                 "timezone": { "type": "string", "description": "Database timezone" },
-                "sslmode": { "type": "string", "description": "SSL mode" }
+                "sslmode": { "type": "string", "description": "SSL mode" },
+                "database": { "type": "string", "description": "Database name" }
               },
               "additionalProperties": false
             }
@@ -98,7 +99,12 @@
         }
       }
     },
-    "externalUrl": { "type": "string", "description": "External CSGHub URL for accessing the hub interface" },
+    "externalUrl": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL for accessing the hub interface. Optional when global.chartContext.isBuiltIn=true." }
+      ]
+    },
     "gateway": {
       "type": "object",
       "description": "Gateway API enablement",
@@ -124,7 +130,7 @@
           "type": "object",
           "description": "Image settings (overrides global.image)",
           "properties": {
-            "registry": { "type": "string", "description": "Image registry" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "Image registry" },
             "repository": { "type": "string", "description": "Image repository" },
             "tag": { "type": "string", "description": "Image version tag" },
             "pullPolicy": { "type": "string", "description": "Image pull policy" },
@@ -135,7 +141,7 @@
           "type": "object",
           "description": "PostgreSQL configuration",
           "properties": {
-            "host": { "type": "string", "description": "PostgreSQL host address" },
+            "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$", "description": "PostgreSQL host address" },
             "port": { "type": "integer", "description": "PostgreSQL port" },
             "database": { "type": "string", "description": "Database name" },
             "user": { "type": "string", "description": "Database username" },
@@ -158,6 +164,68 @@
           "description": "Table rename migration job",
           "properties": {
             "enabled": { "type": "boolean", "description": "Enable or disable rename-tables migration Job" }
+          }
+        }
+      }
+    },
+    "labelStudio": {
+      "type": "object",
+      "description": "Label Studio Configuration",
+      "properties": {
+        "image": {
+          "type": "object",
+          "description": "Image settings (overrides global.image)",
+          "properties": {
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "Image registry" },
+            "repository": { "type": "string", "description": "Image repository" },
+            "tag": { "type": "string", "description": "Image version tag" },
+            "pullPolicy": { "type": "string", "description": "Image pull policy" },
+            "pullSecrets": { "type": "array", "description": "Docker registry secrets", "items": { "type": "string" } }
+          }
+        },
+        "gateway": {
+          "type": "object",
+          "description": "Gateway configuration",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Enable or disable gateway" },
+            "tls": {
+              "type": "object",
+              "description": "TLS settings for gateway",
+              "properties": {
+                "enabled": { "type": "boolean", "description": "Enable or disable TLS" },
+                "secretName": { "type": "string", "description": "TLS secret name" }
+              }
+            }
+          }
+        },
+        "postgresql": {
+          "type": "object",
+          "description": "Database configuration",
+          "properties": {
+            "host": { "type": "string", "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-\\.]*[a-zA-Z0-9])?$", "description": "PostgreSQL host address" },
+            "port": { "type": "integer", "description": "PostgreSQL port" },
+            "database": { "type": "string", "description": "Database name" },
+            "user": { "type": "string", "description": "Database username" },
+            "password": { "type": "string", "description": "Database password" },
+            "timezone": { "type": "string", "description": "Database timezone" },
+            "sslmode": { "type": "string", "description": "SSL mode" }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "description": "Persistent volume configuration",
+          "properties": {
+            "storageClass": { "type": "string", "description": "StorageClass for dynamic provisioning" },
+            "accessModes": { "type": "array", "description": "Volume access permissions", "items": { "type": "string" } },
+            "size": { "type": "string", "description": "Disk space allocation" }
+          }
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Pod security context",
+          "properties": {
+            "runAsUser": { "type": "integer", "description": "User ID" },
+            "runAsGroup": { "type": "integer", "description": "Group ID" }
           }
         }
       }

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -46,9 +46,9 @@
                   "type": "object",
                   "description": "NodePort mapping (required when type is NodePort)",
                   "properties": {
-                    "http": { "type": "integer", "description": "NodePort for HTTP" },
-                    "https": { "type": "integer", "description": "NodePort for HTTPS" },
-                    "gitssh": { "type": "integer", "description": "NodePort for Git SSH" }
+                    "http": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "NodePort for HTTP" },
+                    "https": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "NodePort for HTTPS" },
+                    "gitssh": { "type": "integer", "minimum": 1, "maximum": 65535, "description": "NodePort for Git SSH" }
                   }
                 }
               }
@@ -67,10 +67,10 @@
           "type": "object",
           "description": "Global image configuration",
           "properties": {
-            "registry": { "type": "string" },
-            "registryPolicy": { "type": "string", "description": "Registry policy: default or force" },
+            "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
+            "registryPolicy": { "type": "string", "enum": ["default", "force"], "description": "Registry policy: default or force" },
             "tag": { "type": "string" },
-            "pullPolicy": { "type": "string" },
+            "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
             "pullSecrets": { "type": "array", "items": { "type": "string" } }
           }
         },
@@ -96,14 +96,19 @@
         }
       }
     },
-    "externalUrl": { "type": "string", "description": "External CSGHub URL for accessing the hub interface" },
+    "externalUrl": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL for accessing the hub interface. Optional when global.chartContext.isBuiltIn=true." }
+      ]
+    },
     "image": {
       "type": "object",
       "properties": {
-        "registry": { "type": "string" },
+        "registry": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$" },
         "repository": { "type": "string" },
         "tag": { "type": "string" },
-        "pullPolicy": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
         "pullSecrets": { "type": "array", "items": { "type": "string" } }
       }
     },
@@ -133,8 +138,8 @@
     "service": {
       "type": "object",
       "properties": {
-        "type": { "type": "string" },
-        "port": { "type": "integer" },
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "protocol": { "type": "string" }
       }
     },
@@ -146,14 +151,14 @@
           "description": "Runner operation configuration",
           "properties": {
             "region": { "type": "string", "description": "Region the runner belongs to" },
-            "interval": { "type": "integer", "description": "Communication interval with server (seconds)" },
+            "interval": { "type": "integer", "minimum": 1, "description": "Communication interval with server (seconds)" },
             "namespace": { "type": "string", "description": "Namespace for user-deployed workloads" },
             "mergingNamespace": { "type": "string", "enum": ["multi", "single", "disable"], "description": "Namespace merging strategy" },
             "imageBuilderGitImage": { "type": "string", "description": "Override image builder Git image" },
             "imageBuilderKanikoImage": { "type": "string", "description": "Override image builder Kaniko image" },
             "imageBuilderStatusTTL": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "TTL for kaniko build pod status" },
             "imageBuilderKanikoArgs": { "type": "array", "items": { "type": "string" }, "description": "Extra Kaniko build arguments" },
-            "hearbeatIntervalInSec": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Runner heartbeat interval (seconds)" },
+            "heartbeatIntervalInSec": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Runner heartbeat interval (seconds)" },
             "applicationEndpoint": { "type": "string", "description": "Knative endpoint override (auto-detected if empty)" },
             "networkInterface": { "type": "string", "description": "Host network interface for distributed inference" },
             "storageClassName": { "type": "string", "description": "StorageClass for space persistent volumes" }
@@ -257,7 +262,12 @@
       "type": "object",
       "description": "External registry configuration",
       "properties": {
-        "registry": { "type": "string", "description": "External registry URL" },
+        "registry": {
+          "oneOf": [
+            { "type": "string", "maxLength": 0 },
+            { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*(:[0-9]+)?$", "description": "External registry URL" }
+          ]
+        },
         "repository": { "type": "string", "description": "Repository namespace" },
         "username": { "type": "string", "description": "Registry username" },
         "password": { "type": "string", "description": "Registry password" },


### PR DESCRIPTION
## Summary

Fills in validation for five charts' `values.schema.json`, corresponding to stage 3 ("schema completion") of the fix-plan document.

## Overview

| Chart | Change | Main content |
|---|---|---|
| `csghub` | strengthen existing schema | add enums (`global.edition` ce/ee/saas, `registryPolicy`, `mergingNamespace`, `gateway.service.type`), drop dead declarations (`gateway.moderation`, `server.agent/csgbot/gitlabShell/multiSync/swaggerAPI/memory/objectStore`), add the `aigateway` subtree, image registry pattern |
| `csgship` | strengthen existing schema | enums (`registryPolicy`, `pullPolicy`, `service.type`), add ClusterIP to service.type, port minimum/maximum 1-65535, `externalUrl` pattern |
| `dataflow` | fix + complete | fix `global.postgresql.external` missing the `database` field, add the `labelStudio` subtree, registry/host pattern, externalUrl pattern |
| `runner` | strengthen existing schema | fix `heartbeatIntervalInSec` spelling (old value kept via alias), NodePort range 1-65535, enums (`registryPolicy`, `pullPolicy`, `service.type`), `registry.registry` allows an empty string (for tests) plus a non-empty pattern alternative, externalUrl pattern |
| `agentichub` | **built from scratch** | full schema covering global, externalUrl, hubAPIToken, aigateway (`oneOf: [null, object]` to match the default null), agenticflow, csgbot, postgresql, redis, reloader, memmachine |

## externalUrl builtIn handling

All five charts' `externalUrl` becomes `oneOf: [null, string-with-pattern]`:

- `https?://...` accepts both http and https
- `null` / absent both pass schema validation
- templates don't read `externalUrl` on the `global.chartContext.isBuiltIn=true` branch, so setting null is valid

## Validation coverage (before -> after)

| Type | Before | After |
|---|---|---|
| enum | 0 charts | all 5 charts (`pullPolicy`/`service.type`/`mergingNamespace`/`registryPolicy`/`edition`, etc.) |
| `required` | 0 charts | still none (deferred per discussion, to avoid breaking backward compatibility) |
| `pattern` (URL/registry/host) | 0 charts | all 5 charts |
| `minimum`/`maximum` | 0 charts | all port fields (1-65535), `resourceQuota.gpu >= 0`, `workers >= 1`, `interval >= 1` |
| `additionalProperties: false` | dataflow rejected valid values (missing `database`) | fixed |
| agentichub schema | **none** | full schema built |

## Test plan

- [x] `helm lint charts/*` — 5/5 charts pass
- [x] `helm unittest charts/csghub --with-subchart=false` — 98/98 suite, 407/407 test
- [x] `helm unittest charts/csgship` — 34/34 suite, 190/190 test
- [x] `helm unittest charts/dataflow` — 17/17 suite, 140/140 test
- [x] `helm unittest charts/runner` — 10/10 suite, 146/146 test
- [x] `helm unittest charts/agentichub` — 20/20 suite, 187/187 test
- [x] All 5 schema JSON files are valid (`json.load()` passes)

## Related

- Completes stage 3 of `fix-plan.md` (original plan removed, status folded into the "fixed" table)
- Previous round: #710 (spelling/consistency batch) and #711 (version bump)
