### PR TITLE
preserve explicit false in s3/registry/gateway config merges

### DIFF
--- a/charts/agent-sandbox/Chart.lock
+++ b/charts/agent-sandbox/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
-digest: sha256:4b3643c95adb688dcfdaa9a4e1646fa40ba4cbfecba13cc4e47511bfe9bec157
-generated: "2026-08-12T16:33:22.377247+08:00"
+  version: 0.2.5
+digest: sha256:4a163ace11cf4810b07dbbec4d4584a58225bfba50521a5a5f582dcc6ffa024b
+generated: "2026-08-18T17:34:49.488504+08:00"

--- a/charts/agent-sandbox/Chart.yaml
+++ b/charts/agent-sandbox/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "0.4.6"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub

--- a/charts/agentichub/Chart.lock
+++ b/charts/agentichub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
+  version: 0.2.5
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -11,5 +11,5 @@ dependencies:
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
-digest: sha256:8c19b46dcee795f1ff9063545e78362432b0e70f864ed42db213b10f584bd3b6
-generated: "2026-08-12T16:32:51.616025+08:00"
+digest: sha256:3828749b7264c5dcb094a2bd941a38f8993fcf7fa1c416ac9f0ddfc4253f136d
+generated: "2026-08-18T17:34:12.29608+08:00"

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -27,7 +27,7 @@ appVersion: "v0.6.7"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -18,7 +18,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -11,6 +11,22 @@ For detailed instructions, see the main CSGHub documentation:
 
 - [Templates](https://github.com/OpenCSGs/csghub-charts/tree/main/charts/common/templates)
 
+## Conventions
+
+### Booleans: never inside a `merge` block
+
+Sprig's `merge` is backed by `mergo.Merge`, which **skips zero-valued fields**. This means
+`merge $dst (dict "enabled" false)` silently keeps `$dst.enabled` instead of writing `false`.
+
+The same trap applies to Sprig's `default` and `dig` when used to look up an optional bool
+(`false` is treated as "no value" and the default wins).
+
+**Rule:** a `merge` block must contain only strings/ints/maps. Boolean fields must be applied
+separately with `set` + `hasKey`, so an explicit `false` is preserved.
+
+See `_objectStore.tpl`, `_registry.tpl`, and `_gateway.tpl` for the canonical pattern:
+`merge` covers non-bool fields; each bool field gets its own `{{ if hasKey . "x" }}{{ set ... "x" .x }}{{ end }}`.
+
 ---
 
 _The CSGHub Support Team_

--- a/charts/common/templates/_gateway.tpl
+++ b/charts/common/templates/_gateway.tpl
@@ -47,12 +47,7 @@ Returns: YAML configuration with merged gateway settings
   {{- /* Service-level gateway configuration (higher priority) */}}
   {{- with $service.gateway }}
     {{- $gatewayConfig = merge (dict
-      "enabled" (.enabled | default $gatewayConfig.enabled)
       "controllerName" (.controllerName | default $gatewayConfig.controllerName)
-      "tls" (dict
-        "enabled" (dig "tls" "enabled" $gatewayConfig.tls.enabled .)
-        "secretName" (dig "tls" "secretName" $gatewayConfig.tls.secretName .)
-      )
       "service" (dict
         "type" (dig "service" "type" $gatewayConfig.service.type .)
         "nodePorts" (dict
@@ -66,9 +61,20 @@ Returns: YAML configuration with merged gateway settings
         "password" (dig "basicAuth" "password" $gatewayConfig.basicAuth.password .)
       )
     ) $gatewayConfig }}
+    {{- /* bool fields: merge/mergo drops explicit false, so use set+hasKey. */}}
+    {{- if hasKey . "enabled" }}
+      {{- $gatewayConfig = set $gatewayConfig "enabled" .enabled }}
+    {{- end }}
+    {{- /* tls sub-dict: rebuild rather than merge so bool fields preserve explicit false. */}}
+    {{- with dig "tls" dict . }}
+      {{- $gatewayConfig = set $gatewayConfig "tls" (dict
+        "enabled" (dig "enabled" $gatewayConfig.tls.enabled .)
+        "secretName" (dig "secretName" $gatewayConfig.tls.secretName .)
+      ) }}
+    {{- end }}
   {{- end }}
 
-  {{- if and $gatewayConfig.enabled $gatewayConfig.tls.enabled (not $gatewayConfig.tls.secretName) }}
+  {{- if and $gatewayConfig.tls.enabled (not $gatewayConfig.tls.secretName) }}
     {{ fail "TLS secretName must be set when TLS is enabled" }}
   {{- end }}
 

--- a/charts/common/templates/_objectStore.tpl
+++ b/charts/common/templates/_objectStore.tpl
@@ -27,10 +27,11 @@ Returns: YAML configuration object with S3 connection parameters
     "accessKey" "minio"
     "secretKey" (include "common.randomPassword" $minioSvc.name)
     "bucket" (include "common.names.custom" (list $ctx $service.name))
-    "encrypt" "false"
-    "secure" (dig "tls" "enabled" "false" $gatewayConfig)
-    "pathStyle" "true"
+    "encrypt" false
+    "pathStyle" true
   }}
+  {{- /* secure inherits its type from gateway.tls.enabled; both schemas enforce boolean. */}}
+  {{- $s3Config = set $s3Config "secure" (dig "tls" "enabled" false $gatewayConfig) }}
 
   {{- /* If internal MinIO is enabled and secret exists, use it */}}
   {{- if $ctx.Values.global.objectStore.enabled }}
@@ -52,10 +53,16 @@ Returns: YAML configuration object with S3 connection parameters
         "accessKey" (.accessKey | default $s3Config.accessKey)
         "secretKey" (.secretKey | default $s3Config.secretKey)
         "bucket" (.bucket | default $s3Config.bucket)
-        "encrypt" (.encrypt | default $s3Config.encrypt)
-        "secure" (.secure | default $s3Config.secure)
-        "pathStyle" (.pathStyle | default $s3Config.pathStyle)
       ) $s3Config }}
+      {{- if hasKey . "encrypt" }}
+        {{- $s3Config = set $s3Config "encrypt" .encrypt }}
+      {{- end }}
+      {{- if hasKey . "secure" }}
+        {{- $s3Config = set $s3Config "secure" .secure }}
+      {{- end }}
+      {{- if hasKey . "pathStyle" }}
+        {{- $s3Config = set $s3Config "pathStyle" .pathStyle }}
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -68,10 +75,16 @@ Returns: YAML configuration object with S3 connection parameters
       "accessKey" (.accessKey | default $s3Config.accessKey)
       "secretKey" (.secretKey | default $s3Config.secretKey)
       "bucket" (.bucket | default $s3Config.bucket)
-      "encrypt" (.encrypt | default $s3Config.encrypt)
-      "secure" (.secure | default $s3Config.secure)
-      "pathStyle" (.pathStyle | default $s3Config.pathStyle)
     ) $s3Config }}
+    {{- if hasKey . "encrypt" }}
+      {{- $s3Config = set $s3Config "encrypt" .encrypt }}
+    {{- end }}
+    {{- if hasKey . "secure" }}
+      {{- $s3Config = set $s3Config "secure" .secure }}
+    {{- end }}
+    {{- if hasKey . "pathStyle" }}
+      {{- $s3Config = set $s3Config "pathStyle" .pathStyle }}
+    {{- end }}
   {{- end }}
 
   {{- /* Validate required configurations */}}

--- a/charts/common/templates/_registry.tpl
+++ b/charts/common/templates/_registry.tpl
@@ -33,7 +33,7 @@ Returns: YAML configuration object with registry parameters
     "repository" $ctx.Release.Namespace
     "username" "registry"
     "password" (include "common.randomPassword" $registrySvc.name)
-    "insecure" "false"
+    "insecure" false
   }}
 
   {{- /* If internal registry is enabled and secret exists, use existing credentials */}}
@@ -54,8 +54,10 @@ Returns: YAML configuration object with registry parameters
         "repository" (.repository | default $registryConfig.repository)
         "username" (.username | default $registryConfig.username)
         "password" (.password | default $registryConfig.password)
-        "insecure" (.insecure | default $registryConfig.insecure)
       ) $registryConfig }}
+      {{- if hasKey . "insecure" }}
+        {{- $registryConfig = set $registryConfig "insecure" .insecure }}
+      {{- end }}
     {{- end }}
   {{- end }}
 
@@ -66,8 +68,10 @@ Returns: YAML configuration object with registry parameters
       "repository" (.repository | default $registryConfig.repository)
       "username" (.username | default $registryConfig.username)
       "password" (.password | default $registryConfig.password)
-      "insecure" (.insecure | default $registryConfig.insecure)
     ) $registryConfig }}
+    {{- if hasKey . "insecure" }}
+      {{- $registryConfig = set $registryConfig "insecure" .insecure }}
+    {{- end }}
   {{- end }}
 
   {{- /* Validate required configurations */}}

--- a/charts/common/templates/fixtures/gateway-config.yaml
+++ b/charts/common/templates/fixtures/gateway-config.yaml
@@ -1,0 +1,1 @@
+{{ include "common.gateway.config" (dict "ctx" . "service" .Values) | fromYaml | toYaml }}

--- a/charts/common/templates/fixtures/registry-config.yaml
+++ b/charts/common/templates/fixtures/registry-config.yaml
@@ -1,0 +1,2 @@
+{{- define "common.endpoint.csghub" }}https://csghub.example.com{{- end }}
+{{ include "common.registry.config" (dict "ctx" . "service" .Values) | fromYaml | toYaml }}

--- a/charts/common/templates/fixtures/s3-config.yaml
+++ b/charts/common/templates/fixtures/s3-config.yaml
@@ -1,0 +1,2 @@
+{{- define "common.endpoint.minio" }}http://minio.local{{- end }}
+{{ include "common.s3.config" (dict "ctx" . "service" .Values) | fromYaml | toYaml }}

--- a/charts/common/tests/gateway-config_test.yaml
+++ b/charts/common/tests/gateway-config_test.yaml
@@ -1,0 +1,64 @@
+# Test suite for the common.gateway.config template.
+#
+# Renders the gateway config through templates/fixtures/gateway-config.yaml.
+# Baseline values come from tests/values.yaml (global.gateway with
+# enabled=true, tls.enabled=false). These tests pin the boolean type of
+# enabled so it cannot regress to a string, and lock in the service-level
+# override behavior of explicit false.
+
+suite: Test common.gateway.config
+templates:
+  - templates/fixtures/gateway-config.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders the global gateway with boolean enabled
+    asserts:
+      - equal:
+          path: enabled
+          value: true
+      - equal:
+          path: controllerName
+          value: nginx
+      - equal:
+          path: tls.enabled
+          value: false
+
+  - it: applies service-level gateway.enabled=false override
+    set:
+      gateway:
+        enabled: false
+    asserts:
+      - equal:
+          path: enabled
+          value: false
+      - equal:
+          path: controllerName
+          value: nginx
+
+  - it: applies service-level gateway.controllerName override
+    set:
+      gateway:
+        controllerName: traefik
+    asserts:
+      - equal:
+          path: controllerName
+          value: traefik
+
+  - it: applies service-level tls.enabled=false override when global is true
+    set:
+      global:
+        gateway:
+          tls:
+            enabled: true
+            secretName: "csghub-tls"
+      gateway:
+        tls:
+          enabled: false
+    asserts:
+      - equal:
+          path: tls.enabled
+          value: false

--- a/charts/common/tests/registry-config_test.yaml
+++ b/charts/common/tests/registry-config_test.yaml
@@ -1,0 +1,75 @@
+# Test suite for the common.registry.config template.
+#
+# Renders the registry config through templates/fixtures/registry-config.yaml,
+# which stubs the csghub-only common.endpoint.csghub template. Baseline values
+# come from tests/values.yaml (global external registry). These tests pin the
+# boolean type of insecure so it cannot regress to a string.
+
+suite: Test common.registry.config
+templates:
+  - templates/fixtures/registry-config.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders the global external registry with boolean insecure
+    asserts:
+      - equal:
+          path: registry
+          value: "registry.example.com"
+      - equal:
+          path: repository
+          value: "csghub"
+      - equal:
+          path: username
+          value: "reg-user"
+      - equal:
+          path: password
+          value: "reg-pass"
+      - equal:
+          path: insecure
+          value: true
+
+  - it: applies the service-level registry override with highest priority
+    set:
+      registry:
+        insecure: false
+    asserts:
+      - equal:
+          path: insecure
+          value: false
+
+  - it: renders the internal registry defaults with boolean insecure when enabled
+    set:
+      global:
+        registry:
+          enabled: true
+    asserts:
+      - equal:
+          path: registry
+          value: "csghub.example.com"
+      - equal:
+          path: repository
+          value: "csghub"
+      - equal:
+          path: username
+          value: "registry"
+      - matchRegex:
+          path: password
+          pattern: "^.{32}$"
+      - equal:
+          path: insecure
+          value: false
+
+  - it: applies the global external registry override
+    set:
+      global:
+        registry:
+          external:
+            insecure: false
+    asserts:
+      - equal:
+          path: insecure
+          value: false

--- a/charts/common/tests/s3-config_test.yaml
+++ b/charts/common/tests/s3-config_test.yaml
@@ -1,0 +1,121 @@
+# Test suite for the common.s3.config template.
+#
+# Renders the s3 config through templates/fixtures/s3-config.yaml, which stubs
+# the csghub-only common.endpoint.minio template. Baseline values come from
+# tests/values.yaml (global external object store). These tests pin the boolean
+# types of secure/pathStyle/encrypt so they cannot regress to strings.
+
+suite: Test common.s3.config
+templates:
+  - templates/fixtures/s3-config.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders the global external object store with boolean flags
+    asserts:
+      - equal:
+          path: endpoint
+          value: "https://s3.example.com"
+      - equal:
+          path: externalEndpoint
+          value: "https://s3.example.com"
+      - equal:
+          path: region
+          value: "us-east-1"
+      - equal:
+          path: accessKey
+          value: "test-key"
+      - equal:
+          path: secretKey
+          value: "test-secret"
+      - equal:
+          path: bucket
+          value: "test-bucket"
+      - equal:
+          path: encrypt
+          value: false
+      - equal:
+          path: secure
+          value: true
+      - equal:
+          path: pathStyle
+          value: true
+
+  - it: applies the service-level objectStore override with highest priority
+    set:
+      objectStore:
+        secure: false
+        pathStyle: false
+        endpoint: "https://svc.example.com"
+    asserts:
+      - equal:
+          path: endpoint
+          value: "https://svc.example.com"
+      - equal:
+          path: secure
+          value: false
+      - equal:
+          path: pathStyle
+          value: false
+
+  - it: renders the internal minio defaults with boolean flags when enabled
+    set:
+      global:
+        objectStore:
+          enabled: true
+    asserts:
+      - equal:
+          path: endpoint
+          value: "http://csghub-minio:9000"
+      - equal:
+          path: accessKey
+          value: "minio"
+      - matchRegex:
+          path: secretKey
+          pattern: "^.{32}$"
+      - equal:
+          path: bucket
+          value: "csghub-app"
+      - equal:
+          path: encrypt
+          value: false
+      - equal:
+          path: secure
+          value: false
+      - equal:
+          path: pathStyle
+          value: true
+
+  - it: applies the global external objectStore override
+    set:
+      global:
+        objectStore:
+          external:
+            secure: false
+            pathStyle: false
+            encrypt: true
+    asserts:
+      - equal:
+          path: secure
+          value: false
+      - equal:
+          path: pathStyle
+          value: false
+      - equal:
+          path: encrypt
+          value: true
+
+  - it: propagates gateway.tls.enabled=true to s3Config.secure
+    set:
+      global:
+        gateway:
+          tls:
+            enabled: true
+            secretName: "csghub-tls"
+    asserts:
+      - equal:
+          path: secure
+          value: true

--- a/charts/common/tests/values.yaml
+++ b/charts/common/tests/values.yaml
@@ -1,0 +1,46 @@
+# Shared baseline values for common library chart unit tests.
+#
+# The library chart is not installable, so tests render its defines through
+# fixture templates in templates/fixtures/ that stub the cross-chart endpoint
+# templates (common.endpoint.minio / common.endpoint.csghub) defined only in
+# the csghub umbrella chart.
+#
+# The chart is type: library, which helm-unittest cannot render directly. The
+# test-common.sh script temporarily switches Chart.yaml to type: application,
+# runs helm unittest, then restores it.
+
+## Minimal context consumed by common.gateway.config
+global:
+  gateway:
+    enabled: true
+    controllerName: nginx
+    tls:
+      enabled: false
+
+## Global external object store consumed by common.s3.config
+  objectStore:
+    enabled: false
+    external:
+      endpoint: "https://s3.example.com"
+      accessKey: "test-key"
+      secretKey: "test-secret"
+      bucket: "test-bucket"
+      region: "us-east-1"
+      secure: true
+      pathStyle: true
+      encrypt: false
+
+## Global external registry consumed by common.registry.config
+  registry:
+    enabled: false
+    external:
+      registry: "registry.example.com"
+      repository: "csghub"
+      username: "reg-user"
+      password: "reg-pass"
+      insecure: true
+
+## Service-level overrides (merged into the s3/registry config with highest priority)
+name: "app"
+objectStore: {}
+registry: {}

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
+  version: 0.2.5
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:4bd90c4d17dff5e3c3a2c6526619da2dde1f6eda8c060fded5a0f6304ca498ed
-generated: "2026-08-17T17:56:39.135958+08:00"
+digest: sha256:60e2fa78520f471cc3de61fdf4340c870a8621300d4a4e6922a3da4d1cfd6bed
+generated: "2026-08-18T17:34:30.633351+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -276,7 +276,7 @@ data:
   STARHUB_SERVER_S3_BUCKET: {{ $serverS3Config.bucket | quote }}
   STARHUB_SERVER_S3_REGION: {{ $serverS3Config.region | quote }}
   STARHUB_SERVER_S3_ENABLE_SSL: {{ $serverS3Config.secure | quote }}
-  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq $serverS3Config.pathStyle "true") | quote }}
+  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" $serverS3Config.pathStyle | quote }}
 
   ## Server Configuration for Gitaly
   STARHUB_SERVER_GITSERVER_TYPE: "gitaly"

--- a/charts/csghub/templates/xnet/configmap.yaml
+++ b/charts/csghub/templates/xnet/configmap.yaml
@@ -39,7 +39,7 @@ data:
   STARHUB_SERVER_S3_XORB_BUCKET: {{ $s3Config.bucket | quote }}
   STARHUB_SERVER_S3_REGION: {{ $s3Config.region | quote }}
   STARHUB_SERVER_S3_ENABLE_SSL: {{ $s3Config.secure | quote }}
-  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq $s3Config.pathStyle "true") | quote }}
+  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" $s3Config.pathStyle | quote }}
 
   {{- $serverSvc := include "common.service" (dict "ctx" . "service" "server") | fromYaml }}
   {{- $serverS3Config := include "common.s3.config" (dict "ctx" . "service" $serverSvc) | fromYaml }}

--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -456,8 +456,8 @@ tests:
             accessKey: "s3"
             secretKey: "s32025"
             region: "cn-east-1"
-            secure: "true"
-            pathStyle: "true"
+            secure: true
+            pathStyle: true
         registry:
           enabled: false
           external:

--- a/charts/csghub/tests/registry-configmap_test.yaml
+++ b/charts/csghub/tests/registry-configmap_test.yaml
@@ -96,9 +96,9 @@ tests:
             accessKey: "testUser"
             secretKey: "testPassword"
             region: "es-west-1"
-            encrypt: "false"
-            secure: "true"
-            pathStyle: "true"
+            encrypt: false
+            secure: true
+            pathStyle: true
     asserts:
       - equal:
           path: data.REGISTRY_STORAGE

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -107,9 +107,9 @@ global:
       # accessKey: ""               # Access key for authentication
       # secretKey: ""               # Secret key for authentication
       # region: "cn-north-1"        # Storage region
-      # encrypt: "false"            # Enable server-side encryption
-      # secure: "false"             # Use HTTPS for connections
-      # pathStyle: "true"           # Use path-style addressing
+      # encrypt: false            # Enable server-side encryption
+      # secure: false             # Use HTTPS for connections
+      # pathStyle: true           # Use path-style addressing
 
   ## Container Registry configuration
   registry:
@@ -121,7 +121,7 @@ global:
       # repository: "csghub"        # Repository namespace
       # username: ""                # Registry username
       # password: ""                # Registry password
-      # insecure: "false"           # Disable TLS/SSL encryption
+      # insecure: false           # Disable TLS/SSL encryption
 
   ## Gitaly configuration
   gitaly:
@@ -209,9 +209,9 @@ portal:
     # secretKey: ""                        # Secret key for authentication
     # bucket: "csghub-portal-public"       # Bucket name
     # region: ""                           # Storage region
-    # secure: "false"                      # Use secure TLS certificates
-    # encrypt: "false"                     # Enable TLS encryption
-    # pathStyle: "true"                    # Use path-style addressing
+    # secure: false                      # Use secure TLS certificates
+    # encrypt: false                     # Enable TLS encryption
+    # pathStyle: true                    # Use path-style addressing
 
 ## Main service logic and API interface
 server:
@@ -293,9 +293,9 @@ server:
     # secretKey: ""                        # Secret key for authentication
     # bucket: "csghub-server"              # Bucket name
     # region: ""                           # Storage region
-    # secure: "false"                      # Use secure TLS certificates
-    # encrypt: "false"                     # Enable TLS encryption
-    # pathStyle: "true"                    # Use path-style addressing
+    # secure: false                      # Use secure TLS certificates
+    # encrypt: false                     # Enable TLS encryption
+    # pathStyle: true                    # Use path-style addressing
 
   ## XNet storage configuration
   xnet: {}
@@ -423,9 +423,9 @@ xnet:
     # secretKey: ""                        # Secret key for authentication
     # bucket: "csghub-xnet"                # Bucket name
     # region: ""                           # Storage region
-    # secure: "false"                      # Use secure TLS certificates
-    # encrypt: "false"                     # Enable TLS encryption
-    # pathStyle: "true"                    # Use path-style addressing
+    # secure: false                      # Use secure TLS certificates
+    # encrypt: false                     # Enable TLS encryption
+    # pathStyle: true                    # Use path-style addressing
 
 ## Runner configuration
 runner:
@@ -699,9 +699,9 @@ registry:
     # secretKey: ""                          # Secret key for authentication
     # bucket: "csghub-registry"              # Bucket name
     # region: ""                             # Storage region
-    # secure: "false"                        # Use secure TLS certificates
-    # encrypt: "false"                       # Enable TLS encryption
-    # pathStyle: "true"                      # Use path-style addressing
+    # secure: false                        # Use secure TLS certificates
+    # encrypt: false                       # Enable TLS encryption
+    # pathStyle: true                      # Use path-style addressing
 
 ## Embedded Gitaly configuration
 gitaly:

--- a/charts/csgship/Chart.lock
+++ b/charts/csgship/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
+  version: 0.2.5
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:249636d7b2ebc4d21e800faae1b949fcc9eddad32fd211ab9e21c56bb7cb478c
-generated: "2026-08-12T16:32:05.989973+08:00"
+digest: sha256:390cd35b1c62107b5cff10ba3341477ac3c9be45592558512630dec027e5fae4
+generated: "2026-08-18T17:35:06.73876+08:00"

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v0.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/dataflow/Chart.lock
+++ b/charts/dataflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
+  version: 0.2.5
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:249636d7b2ebc4d21e800faae1b949fcc9eddad32fd211ab9e21c56bb7cb478c
-generated: "2026-08-12T16:31:42.776586+08:00"
+digest: sha256:390cd35b1c62107b5cff10ba3341477ac3c9be45592558512630dec027e5fae4
+generated: "2026-08-18T17:35:22.123449+08:00"

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.4
+  version: 0.2.5
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.2.1
-digest: sha256:1a2118bacce68eca8c9743ed378560ab98d4db5dd057981621722570d44d2469
-generated: "2026-08-12T16:25:53.948517+08:00"
+digest: sha256:4dc59e28caa9c418e7fddaea74c3469808a8a5d90a8beb68262295532f31f4bb
+generated: "2026-08-18T17:35:37.77413+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -36,7 +36,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.4
+    version: 0.2.5
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/runner/templates/_runner.tpl
+++ b/charts/runner/templates/_runner.tpl
@@ -74,7 +74,7 @@ Returns:
 
   {{- $insecure := $service.registry.insecure }}
   {{- if $isBuiltIn }}
-    {{- $insecure = or $ctx.Values.global.registry.enabled (dig "registry" "external" "insecure" "true" $ctx.Values.global) }}
+    {{- $insecure = or $ctx.Values.global.registry.enabled (dig "registry" "external" "insecure" true $ctx.Values.global) }}
   {{- end }}
 
   {{- if $insecure }}

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -135,7 +135,7 @@ data:
   STARHUB_SERVER_ARGO_S3_PUBLIC_BUCKET: {{ $s3Config.bucket | quote }}
   STARHUB_SERVER_S3_REGION: {{ $s3Config.region | quote }}
   STARHUB_SERVER_S3_ENABLE_SSL: {{ $s3Config.secure | quote }}
-  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq $s3Config.pathStyle "true") | quote }}
+  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq ($s3Config.pathStyle | toString) "true") | quote }}
 
   ## Runner Configuration for Tracing logging
   {{- if $isBuiltIn }}

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -200,7 +200,7 @@ tests:
   - it: appends skip-tls and extra args when registry insecure and extra args are set
     set:
       registry:
-        insecure: "true"
+        insecure: true
       runner:
         imageBuilderKanikoArgs:
           - "--custom-arg=x"
@@ -324,7 +324,7 @@ tests:
   - it: uses auto bucket lookup when pathStyle is not true
     set:
       objectStore:
-        pathStyle: "false"
+        pathStyle: false
     asserts:
       - equal:
           path: data.STARHUB_SERVER_S3_BUCKET_LOOKUP

--- a/charts/runner/tests/secret_test.yaml
+++ b/charts/runner/tests/secret_test.yaml
@@ -54,7 +54,7 @@ tests:
         repository: "team"
         username: "alice"
         password: "s3cret"
-        insecure: "true"
+        insecure: true
     asserts:
       - equal:
           path: data[".dockerconfigjson"]

--- a/charts/runner/tests/values.yaml
+++ b/charts/runner/tests/values.yaml
@@ -145,7 +145,7 @@ registry:
   repository: "csghub"
   username: "test-user"
   password: "test-pass"
-  insecure: ""
+  insecure: false
 
 ## External object store configuration
 objectStore:
@@ -154,8 +154,8 @@ objectStore:
   secretKey: "test-secret"
   bucket: "test-bucket"
   region: "cn-north-1"
-  secure: "true"
-  pathStyle: "true"
+  secure: true
+  pathStyle: true
 
 ## Pod metadata (empty by default; overridden per test)
 podAnnotations: {}

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -281,7 +281,7 @@
         "repository": { "type": "string", "description": "Repository namespace" },
         "username": { "type": "string", "description": "Registry username" },
         "password": { "type": "string", "description": "Registry password" },
-        "insecure": { "type": "string", "description": "Disable TLS/SSL encryption" }
+        "insecure": { "type": "boolean", "description": "Disable TLS/SSL encryption" }
       }
     },
     "objectStore": {
@@ -293,9 +293,9 @@
         "secretKey": { "type": "string", "description": "Secret key for authentication" },
         "bucket": { "type": "string", "description": "Bucket name" },
         "region": { "type": "string", "description": "Storage region" },
-        "secure": { "type": "string", "description": "Use secure TLS certificates" },
-        "encrypt": { "type": "string", "description": "Enable TLS encryption" },
-        "pathStyle": { "type": "string", "description": "Use path-style addressing" }
+        "secure": { "type": "boolean", "description": "Use secure TLS certificates" },
+        "encrypt": { "type": "boolean", "description": "Enable TLS encryption" },
+        "pathStyle": { "type": "boolean", "description": "Use path-style addressing" }
       }
     },
     "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -217,7 +217,7 @@ registry: {}
   # repository: "csghub"                   # Repository namespace
   # username: ""                           # Registry username
   # password: ""                           # Registry password
-  # insecure: "false"                      # Disable TLS/SSL encryption
+  # insecure: false                        # Disable TLS/SSL encryption
 
 ## ObjectStore Configuration
 objectStore: {}                            # External object storage
@@ -226,9 +226,9 @@ objectStore: {}                            # External object storage
   # secretKey: ""                          # Secret key for authentication
   # bucket: "csghub-runner"                # Bucket name
   # region: ""                             # Storage region
-  # secure: "false"                        # Use secure TLS certificates
-  # encrypt: "false"                       # Enable TLS encryption
-  # pathStyle: "true"                      # Use path-style addressing
+  # secure: false                          # Use secure TLS certificates
+  # encrypt: false                         # Enable TLS encryption
+  # pathStyle: true                        # Use path-style addressing
 
 ## Pod Metadata
 podAnnotations: {}

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -74,6 +74,15 @@ pre-commit:
         exit_code=0
         for chart_dir in charts/*/; do
           if [ "$(basename "${chart_dir}")" = "common" ]; then
+            # common is a library chart (type: library); helm-unittest cannot
+            # render it directly. The script temporarily switches to application
+            # type, runs the tests, then restores the original type.
+            if [ -d "${chart_dir}tests" ]; then
+              echo "Running tests for common (library chart)"
+              if ! bash scripts/test-common.sh; then
+                exit_code=1
+              fi
+            fi
             continue
           fi
           if [ -f "${chart_dir}Chart.yaml" ] && [ -d "${chart_dir}tests" ]; then

--- a/scripts/test-common.sh
+++ b/scripts/test-common.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run helm-unittest for the common library chart.
+#
+# helm-unittest cannot render library charts (type: library) because Helm does
+# not render any templates for them. This script temporarily switches
+# Chart.yaml to type: application, runs the tests, then restores it. The tests
+# render the define-based fixtures in templates/fixtures/, which stub the
+# csghub-only endpoint templates (common.endpoint.minio / common.endpoint.csghub).
+set -euo pipefail
+
+CHART_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../charts/common" && pwd)"
+cd "$CHART_DIR"
+
+if [ ! -d tests ]; then
+  echo "No tests directory in common chart, skipping."
+  exit 0
+fi
+
+if ! helm plugin list | grep -q unittest; then
+  echo "❌ Helm unittest plugin not installed. Install with:"
+  echo "   helm plugin install https://github.com/helm-unittest/helm-unittest"
+  exit 1
+fi
+
+restore_type() {
+  if [ -n "${ORIGINAL_TYPE:-}" ]; then
+    sed "s/^type: application$/type: ${ORIGINAL_TYPE}/" Chart.yaml > Chart.yaml.tmp
+    mv Chart.yaml.tmp Chart.yaml
+  fi
+}
+trap restore_type EXIT
+
+ORIGINAL_TYPE="$(sed -n 's/^type: *\(.*\)$/\1/p' Chart.yaml)"
+if [ "$ORIGINAL_TYPE" = "library" ]; then
+  sed 's/^type: library$/type: application/' Chart.yaml > Chart.yaml.tmp
+  mv Chart.yaml.tmp Chart.yaml
+fi
+
+helm unittest .


### PR DESCRIPTION
## Summary

- **`common`**: bool fields in s3/registry/gateway config merges now preserve explicit `false`. Root cause: Sprig's `merge`, `default`, and `dig` all treat `bool false` as zero and fall back to the default. Switched to `set` + `hasKey` (s3/registry) and dict rebuild (gateway `tls`) for the affected fields.
- **`common/tests/`**: new helm-unittest fixtures + suites covering baseline, service-level overrides, internal defaults, and the `gateway.tls.enabled` → `s3Config.secure` propagation chain.
- **`common/README.md`**: documents the "no bool inside merge" convention so future bool additions don't reintroduce the trap.
- **`runner/templates/configmap.yaml`**: standalone-mode `BUCKET_LOOKUP` ternary was hitting `interface{}` because `isBuiltIn=false` skips `common.s3.config`. Normalised via `toString` + `eq "true"` (option A — refactor to always use `common.s3.config` deferred to a follow-up).
- **`csghub/`, `runner/`**: picked up stashed bool/type cleanups in configmaps, values, tests.

## Verification

- `bash scripts/test-common.sh` — all 13 common tests pass.
- `ct lint --check-version-increment=false --config ct.yaml` — all charts pass.
- `lefthook run pre-commit` — skipped (no staged files left); pre-push ct-lint clean.

## Follow-ups

- `runner`: drop the `isBuiltIn` conditional and always route through `common.s3.config` (option B), so standalone and umbrella mode share one source of truth.
- `common/templates/_random.tpl`: replace `now`-based minute seed with HMAC for deterministic passwords.