### PR TITLE
fix: accept pathStyle as bool or string in s3 bucket lookup

### DIFF
--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -276,7 +276,7 @@ data:
   STARHUB_SERVER_S3_BUCKET: {{ $serverS3Config.bucket | quote }}
   STARHUB_SERVER_S3_REGION: {{ $serverS3Config.region | quote }}
   STARHUB_SERVER_S3_ENABLE_SSL: {{ $serverS3Config.secure | quote }}
-  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" $serverS3Config.pathStyle | quote }}
+  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq ($serverS3Config.pathStyle | toString) "true") | quote }}
 
   ## Server Configuration for Gitaly
   STARHUB_SERVER_GITSERVER_TYPE: "gitaly"

--- a/charts/csghub/templates/xnet/configmap.yaml
+++ b/charts/csghub/templates/xnet/configmap.yaml
@@ -39,7 +39,7 @@ data:
   STARHUB_SERVER_S3_XORB_BUCKET: {{ $s3Config.bucket | quote }}
   STARHUB_SERVER_S3_REGION: {{ $s3Config.region | quote }}
   STARHUB_SERVER_S3_ENABLE_SSL: {{ $s3Config.secure | quote }}
-  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" $s3Config.pathStyle | quote }}
+  STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq ($s3Config.pathStyle | toString) "true") | quote }}
 
   {{- $serverSvc := include "common.service" (dict "ctx" . "service" "server") | fromYaml }}
   {{- $serverS3Config := include "common.s3.config" (dict "ctx" . "service" $serverSvc) | fromYaml }}


### PR DESCRIPTION
## Problem

`helm upgrade --install` fails during template rendering with:

```
Error: UPGRADE FAILED: csghub/templates/xnet/configmap.yaml:42:69
  executing "csghub/templates/xnet/configmap.yaml" at <$s3Config.pathStyle>:
    wrong type for value; expected bool; got string
```

`ternary` was passed `$s3Config.pathStyle` directly as its condition, so it only worked when the value was a real boolean. When users set `pathStyle: "true"` (a string, as documented in the chart's `values.yaml`), rendering fails. This regressed in `d66eb853`, which dropped the previous string coercion.

## Fix

Coerce `pathStyle` to string and compare before handing it to `ternary` — the same pattern already used in `charts/runner/templates/configmap.yaml`:

```yaml
STARHUB_SERVER_S3_BUCKET_LOOKUP: {{ ternary "path" "auto" (eq ($s3Config.pathStyle | toString) "true") | quote }}
```

Applied to:
- `charts/csghub/templates/xnet/configmap.yaml`
- `charts/csghub/templates/csghub/configmap.yaml`

## Verification

| `pathStyle` value | `STARHUB_SERVER_S3_BUCKET_LOOKUP` |
|---|---|
| `"true"` (string) | `"path"` |
| `true` (bool) | `"path"` |
| `"false"` (string) | `"auto"` |
| `false` (bool) | `"auto"` |
| unset (helper default `true`) | `"path"` |

All helm-unittest suites (csghub, common, runner, etc.), helm template rendering, and ct lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
