### PR TITLE
fix(csghub): make workload probes/lifecycle overridable

### DIFF
--- a/charts/csghub/templates/casdoor/deployment.yaml
+++ b/charts/csghub/templates/casdoor/deployment.yaml
@@ -68,6 +68,10 @@ spec:
             - containerPort: 8000
               name: {{ dig "service" "name" $service.name $service }}
               protocol: {{ dig "service" "protocol" "TCP" $service }}
+          {{- if $service.envFrom }}
+          envFrom:
+            {{- toYaml $service.envFrom | nindent 12 }}
+          {{- end }}
           {{- with $service.environments }}
           env:
           {{- range $key, $value := . }}
@@ -85,17 +89,27 @@ spec:
           {{- if $service.volumeMounts }}
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8000
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /api/health
               port: 8000
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/accounting/deployment.yaml
+++ b/charts/csghub/templates/csghub/accounting/deployment.yaml
@@ -185,8 +185,10 @@ spec:
       {{- if $service.volumes }}
         {{- toYaml $service.volumes | nindent 8 }}
       {{- end }}
+      {{- if eq .Values.global.edition "saas" }}
       {{- if $paymentSvc.volumes }}
         {{- toYaml $paymentSvc.volumes | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- if $service.nodeSelector }}
       nodeSelector:

--- a/charts/csghub/templates/csghub/accounting/deployment.yaml
+++ b/charts/csghub/templates/csghub/accounting/deployment.yaml
@@ -93,11 +93,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8086
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}
@@ -153,11 +158,16 @@ spec:
           volumeMounts:
             {{- toYaml $paymentSvc.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $paymentSvc.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $paymentSvc.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8090
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $paymentSvc.readinessProbe }}
           readinessProbe:
             {{- toYaml $paymentSvc.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/aigateway/deployment.yaml
+++ b/charts/csghub/templates/csghub/aigateway/deployment.yaml
@@ -95,11 +95,20 @@ spec:
           volumeMounts:
             {{- toYaml $moderation.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $moderation.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $moderation.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8089
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $moderation.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $moderation.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -107,6 +116,7 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $moderation.startupProbe }}
           startupProbe:
             {{- toYaml $moderation.startupProbe | nindent 12 }}
@@ -162,11 +172,16 @@ spec:
           volumeMounts:
             {{- toYaml $aigateway.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $aigateway.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $aigateway.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8094
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $aigateway.readinessProbe }}
           readinessProbe:
             {{- toYaml $aigateway.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/dataviewer/deployment.yaml
+++ b/charts/csghub/templates/csghub/dataviewer/deployment.yaml
@@ -93,11 +93,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8093
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/fedap/deployment.yaml
+++ b/charts/csghub/templates/csghub/fedap/deployment.yaml
@@ -94,11 +94,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8099
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/llmlog/deployment.yaml
+++ b/charts/csghub/templates/csghub/llmlog/deployment.yaml
@@ -92,6 +92,10 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/mirror/deployment.yaml
+++ b/charts/csghub/templates/csghub/mirror/deployment.yaml
@@ -146,11 +146,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8092
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/notifier/deployment.yaml
+++ b/charts/csghub/templates/csghub/notifier/deployment.yaml
@@ -93,11 +93,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8095
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/portal/deployment.yaml
+++ b/charts/csghub/templates/csghub/portal/deployment.yaml
@@ -95,11 +95,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8090
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/rproxy/coredns/deployment.yaml
+++ b/charts/csghub/templates/csghub/rproxy/coredns/deployment.yaml
@@ -90,11 +90,19 @@ spec:
           volumeMounts:
             - name: corefile
               mountPath: /etc/coredns
+          {{- if $service.volumeMounts }}
+            {{- toYaml $service.volumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 53
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/rproxy/deployment.yaml
+++ b/charts/csghub/templates/csghub/rproxy/deployment.yaml
@@ -106,11 +106,20 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8083
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -118,6 +127,7 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}
@@ -160,11 +170,19 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/nginx/conf.d
+          {{- if $service.volumeMounts }}
+            {{- toYaml $service.volumeMounts | nindent 12 }}
+          {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 80
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/server/deployment.yaml
+++ b/charts/csghub/templates/csghub/server/deployment.yaml
@@ -99,11 +99,20 @@ spec:
           {{- if $service.volumeMounts }}
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8080
             initialDelaySeconds: 20
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -113,6 +122,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             failureThreshold: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/trustregistry/deployment.yaml
+++ b/charts/csghub/templates/csghub/trustregistry/deployment.yaml
@@ -94,11 +94,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8098
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/csghub/user/deployment.yaml
+++ b/charts/csghub/templates/csghub/user/deployment.yaml
@@ -95,11 +95,16 @@ spec:
           {{- if $service.volumeMounts }}
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/gitaly/statefulset.yaml
+++ b/charts/csghub/templates/gitaly/statefulset.yaml
@@ -87,16 +87,26 @@ spec:
           resources:
             {{- toYaml $service.resources | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8075
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             exec:
               command: [ "/scripts/healthcheck" ]
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/gitlab-shell/deployment.yaml
+++ b/charts/csghub/templates/gitlab-shell/deployment.yaml
@@ -93,11 +93,16 @@ spec:
           {{- if $service.volumeMounts }}
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 22
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}

--- a/charts/csghub/templates/minio/statefulset.yaml
+++ b/charts/csghub/templates/minio/statefulset.yaml
@@ -98,17 +98,27 @@ spec:
           resources:
             {{- toYaml $service.resources | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 9000
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /minio/health/live
               port: 9000
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/nats/statefulset.yaml
+++ b/charts/csghub/templates/nats/statefulset.yaml
@@ -90,17 +90,27 @@ spec:
           resources:
             {{- toYaml $service.resources | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 4222
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: 8222
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/postgresql/statefulset.yaml
+++ b/charts/csghub/templates/postgresql/statefulset.yaml
@@ -111,6 +111,10 @@ spec:
           resources:
             {{- toYaml $service.resources | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 5432
@@ -118,6 +122,11 @@ spec:
             periodSeconds: 7
             timeoutSeconds: 5
             failureThreshold: 10
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             exec:
               command:
@@ -133,6 +142,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 7
             timeoutSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/redis/statefulset.yaml
+++ b/charts/csghub/templates/redis/statefulset.yaml
@@ -95,11 +95,20 @@ spec:
           resources:
             {{- toYaml $service.resources | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 6379
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             exec:
               command:
@@ -115,6 +124,7 @@ spec:
                 - "ping"
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/registry/deployment.yaml
+++ b/charts/csghub/templates/registry/deployment.yaml
@@ -89,11 +89,20 @@ spec:
           {{- if $service.volumeMounts }}
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 5000
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
+          {{- if $service.readinessProbe }}
+          readinessProbe:
+            {{- toYaml $service.readinessProbe | nindent 12 }}
+          {{- else }}
           readinessProbe:
             httpGet:
               path: /
@@ -103,6 +112,7 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 10
             failureThreshold: 5
+          {{- end }}
           {{- if $service.startupProbe }}
           startupProbe:
             {{- toYaml $service.startupProbe | nindent 12 }}

--- a/charts/csghub/templates/temporal/deployment.yaml
+++ b/charts/csghub/templates/temporal/deployment.yaml
@@ -93,11 +93,16 @@ spec:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 7233
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}
@@ -110,10 +115,15 @@ spec:
           securityContext:
             {{- toYaml $service.securityContext | nindent 12 }}
           {{- end }}
+          {{- if $service.lifecycle }}
+          lifecycle:
+            {{- toYaml $service.lifecycle | nindent 12 }}
+          {{- else }}
           lifecycle:
             postStart:
               exec:
                 command: [ "/bin/sh", "-c", "sleep 8" ]
+          {{- end }}
           {{- if $service.stdin }}
           stdin: {{ $service.stdin }}
           {{- end }}

--- a/charts/csghub/templates/xnet/deployment.yaml
+++ b/charts/csghub/templates/xnet/deployment.yaml
@@ -92,11 +92,16 @@ spec:
           volumeMounts:
             {{- toYaml $service.volumeMounts | nindent 12 }}
           {{- end }}
+          {{- if $service.livenessProbe }}
+          livenessProbe:
+            {{- toYaml $service.livenessProbe | nindent 12 }}
+          {{- else }}
           livenessProbe:
             tcpSocket:
               port: 8097
             initialDelaySeconds: 10
             periodSeconds: 5
+          {{- end }}
           {{- if $service.readinessProbe }}
           readinessProbe:
             {{- toYaml $service.readinessProbe | nindent 12 }}
@@ -109,10 +114,15 @@ spec:
           securityContext:
             {{- toYaml $service.securityContext | nindent 12 }}
           {{- end }}
+          {{- if $service.lifecycle }}
+          lifecycle:
+            {{- toYaml $service.lifecycle | nindent 12 }}
+          {{- else }}
           lifecycle:
             postStart:
               exec:
                 command: [ "/bin/sh", "-c", "sleep 8" ]
+          {{- end }}
           {{- if $service.stdin }}
           stdin: {{ $service.stdin }}
           {{- end }}


### PR DESCRIPTION
Audited all csghub deployment/statefulset templates and fixed the issues found across two commits.

### `309fa190` — bug fixes
- `csghub/accounting/deployment.yaml`: gate `$paymentSvc.volumes` behind the `saas` edition condition so no orphaned pod volumes are emitted when `global.edition != saas`
- `csghub/llmlog/deployment.yaml`: add the conditional `livenessProbe` block that every other csghub-internal service already renders

### `9562e350` — make workload fields overridable from values (22 files)
- `casdoor/deployment.yaml`: add an optional `{{- if $service.envFrom }}` block so users can inject arbitrary envFrom via values; casdoor's own config still comes from the `/conf` volume mount (no hardcoded `configMapRef: core`)
- All workload templates: wrap the hardcoded `livenessProbe` / `readinessProbe` / `lifecycle` / `volumeMounts` in `{{- if $service.X }} … {{- else }} <previous default> {{- end }}` so every field is overridable from values while existing behavior is preserved by default
- Untouched: the `mirror/repo` and `temporal/console` containers, which already used the conditional pattern

## Test
- ✔ helm unittest 407/407 PASS (98 suites)
- ✔ lefthook pre-commit hooks pass (build-dependency / helm-template / helm-unittest / yaml-validate / conventional-commit)
- ✔ rendered output under default values is semantically identical to HEAD (only randomly generated token diffs)