### PR TITLE
Adapt existsing secrets

### DIFF
--- a/charts/agent-sandbox/Chart.lock
+++ b/charts/agent-sandbox/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
-digest: sha256:2b77b2e9c15d7555c121fa6a577d524dd4f4cdd7b56c18c8c2e5b982ae53e369
-generated: "2026-08-31T14:16:11.449755+08:00"
+  version: 0.2.8
+digest: sha256:b864f10f2fafedab204630c51de109480e0743ae4df3f424ef43f1fd56a39530
+generated: "2026-09-04T10:48:50.738946+08:00"

--- a/charts/agent-sandbox/Chart.yaml
+++ b/charts/agent-sandbox/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "0.5.4"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub

--- a/charts/agentichub/Chart.lock
+++ b/charts/agentichub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
+  version: 0.2.8
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -11,5 +11,5 @@ dependencies:
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
-digest: sha256:ac147d8c3d7b6c456afcd08c160692e68c32153c4bb2bf0a50732e8798556135
-generated: "2026-08-31T14:18:16.318162+08:00"
+digest: sha256:ca773d6ddeb196d45da8997192bd7bcfb347cf00c76c81f5dbaeb860508d6356
+generated: "2026-09-04T10:50:03.319155+08:00"

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.8
+version: 0.6.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,7 +27,7 @@ appVersion: "v0.6.7"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -86,6 +86,10 @@ global:
       # password: ""                # Database password
       # timezone: "Etc/UTC"         # Database timezone
       # sslmode: "prefer"           # SSL mode
+    ## Reference an existing Secret containing POSTGRES_HOST/POSTGRES_PORT/
+    ## POSTGRES_USER/POSTGRES_PASSWORD/[POSTGRES_SSLMODE]. Only honored when
+    ## enabled=false. The Secret must be provisioned in the release namespace.
+    existingSecret: ""
 
   ## Redis configuration
   redis:
@@ -96,6 +100,9 @@ global:
       # host: "<redis_host>"        # Redis server hostname or IP
       # port: 6379                  # Redis port number
       # password: ""                # Redis authentication password
+    ## Reference an existing Secret containing REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/
+    ## [REDIS_USER]/[REDIS_DATABASE]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## subChart deployment context
   chartContext:

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -18,7 +18,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/_gitaly.tpl
+++ b/charts/common/templates/_gitaly.tpl
@@ -4,6 +4,38 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{/*
+Resolve the name of the Secret that supplies the Gitaly connection.
+
+Resolution order: service-level gitaly.existingSecret > global.gitaly.existingSecret.
+Only honored when global.gitaly.enabled=false. When set, the connection is resolved
+from the Secret's GITALY_* keys (GITALY_HOST/GITALY_PORT/GITALY_TOKEN, optional
+GITALY_STORAGE/GITALY_SCHEME) via lookup.
+
+Usage:
+{{ include "common.gitaly.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
+*/}}
+{{- define "common.gitaly.existingSecret" }}
+  {{- $service := .service }}
+  {{- $ctx := .ctx }}
+  {{- if not $ctx.Values.global.gitaly.enabled }}
+    {{- $existingSecret := "" }}
+    {{- with $service.gitaly }}
+      {{- if .existingSecret }}
+        {{- $existingSecret = .existingSecret }}
+      {{- end }}
+    {{- end }}
+    {{- if not $existingSecret }}
+      {{- with $ctx.Values.global.gitaly }}
+        {{- if .existingSecret }}
+          {{- $existingSecret = .existingSecret }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $existingSecret -}}
+  {{- end }}
+{{- end }}
+
+{{/*
 Generate Gitaly Connection Configuration
 
 Usage:
@@ -63,6 +95,31 @@ Returns: YAML configuration object with Gitaly connection parameters
       "token" (.token | default $gitalyConfig.token)
       "scheme" (.scheme | default $gitalyConfig.scheme)
     ) $gitalyConfig }}
+  {{- end }}
+
+  {{- /* existingSecret: pull real connection values from the referenced Secret. */}}
+  {{- $existingSecret := include "common.gitaly.existingSecret" (dict "ctx" $ctx "service" $service) }}
+  {{- if $existingSecret }}
+    {{- $secretData := (lookup "v1" "Secret" $ctx.Release.Namespace $existingSecret).data | default dict }}
+    {{- $realHost := dig "GITALY_HOST" "" $secretData | b64dec }}
+    {{- $realPort := dig "GITALY_PORT" "" $secretData | b64dec }}
+    {{- $realToken := dig "GITALY_TOKEN" "" $secretData | b64dec }}
+    {{- $realStorage := dig "GITALY_STORAGE" "" $secretData | b64dec }}
+    {{- $realScheme := dig "GITALY_SCHEME" "" $secretData | b64dec }}
+    {{- if $realHost }}
+      {{- $portValue := $gitalyConfig.port }}
+      {{- if $realPort }}
+        {{- $parsed := $realPort | atoi }}
+        {{- if $parsed }}{{ $portValue = $parsed | toString }}{{ end }}
+      {{- end }}
+      {{- $gitalyConfig = dict
+        "host" $realHost
+        "port" $portValue
+        "storage" (or $realStorage $gitalyConfig.storage)
+        "token" (or $realToken $gitalyConfig.token)
+        "scheme" (or $realScheme $gitalyConfig.scheme)
+      }}
+    {{- end }}
   {{- end }}
 
   {{- /* Validate required configurations */}}

--- a/charts/common/templates/_objectStore.tpl
+++ b/charts/common/templates/_objectStore.tpl
@@ -1,4 +1,36 @@
 {{/*
+Resolve the name of the Secret that supplies the object store connection.
+
+Resolution order: service-level objectStore.existingSecret > global.objectStore.existingSecret.
+Only honored when global.objectStore.enabled=false. When set, the connection is resolved
+from the Secret's OBJECT_STORE_* keys (OBJECT_STORE_ENDPOINT/OBJECT_STORE_ACCESS_KEY/
+OBJECT_STORE_SECRET_KEY, optional OBJECT_STORE_REGION/OBJECT_STORE_BUCKET) via lookup.
+
+Usage:
+{{ include "common.objectStore.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
+*/}}
+{{- define "common.objectStore.existingSecret" }}
+  {{- $service := .service }}
+  {{- $ctx := .ctx }}
+  {{- if not $ctx.Values.global.objectStore.enabled }}
+    {{- $existingSecret := "" }}
+    {{- with $service.objectStore }}
+      {{- if .existingSecret }}
+        {{- $existingSecret = .existingSecret }}
+      {{- end }}
+    {{- end }}
+    {{- if not $existingSecret }}
+      {{- with $ctx.Values.global.objectStore }}
+        {{- if .existingSecret }}
+          {{- $existingSecret = .existingSecret }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $existingSecret -}}
+  {{- end }}
+{{- end }}
+
+{{/*
 Generate S3/MinIO Connection Configuration
 
 Usage:
@@ -84,6 +116,30 @@ Returns: YAML configuration object with S3 connection parameters
     {{- end }}
     {{- if hasKey . "pathStyle" }}
       {{- $s3Config = set $s3Config "pathStyle" .pathStyle }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* existingSecret: pull real connection values from the referenced Secret. */}}
+  {{- $existingSecret := include "common.objectStore.existingSecret" (dict "ctx" $ctx "service" $service) }}
+  {{- if $existingSecret }}
+    {{- $secretData := (lookup "v1" "Secret" $ctx.Release.Namespace $existingSecret).data | default dict }}
+    {{- $realEndpoint := dig "OBJECT_STORE_ENDPOINT" "" $secretData | b64dec }}
+    {{- $realAccessKey := dig "OBJECT_STORE_ACCESS_KEY" "" $secretData | b64dec }}
+    {{- $realSecretKey := dig "OBJECT_STORE_SECRET_KEY" "" $secretData | b64dec }}
+    {{- $realRegion := dig "OBJECT_STORE_REGION" "" $secretData | b64dec }}
+    {{- $realBucket := dig "OBJECT_STORE_BUCKET" "" $secretData | b64dec }}
+    {{- if $realEndpoint }}
+      {{- $s3Config = dict
+        "endpoint" $realEndpoint
+        "externalEndpoint" $realEndpoint
+        "region" (or $realRegion $s3Config.region)
+        "accessKey" (or $realAccessKey $s3Config.accessKey)
+        "secretKey" (or $realSecretKey $s3Config.secretKey)
+        "bucket" (or $realBucket $s3Config.bucket)
+        "encrypt" $s3Config.encrypt
+        "secure" $s3Config.secure
+        "pathStyle" $s3Config.pathStyle
+      }}
     {{- end }}
   {{- end }}
 

--- a/charts/common/templates/_postgres.tpl
+++ b/charts/common/templates/_postgres.tpl
@@ -4,6 +4,42 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{/*
+Resolve the name of the Secret that supplies the PostgreSQL connection.
+
+Resolution order: service-level postgresql.existingSecret > global.postgresql.existingSecret.
+Only honored when global.postgresql.enabled=false; in internal mode the chart deploys its
+own PostgreSQL with a chart-generated password and this helper returns empty so every
+consumer (Deployment/Job/ConfigMap/wait-for-postgresql) falls back to the internal
+connection. When set, common.postgresql.config resolves the connection from the Secret's
+POSTGRES_* keys (POSTGRES_HOST/POSTGRES_PORT/POSTGRES_USER/POSTGRES_PASSWORD/POSTGRES_SSLMODE)
+via lookup. The database name stays chart-known per service, so a single shared Secret can
+serve every service while each keeps its own database.
+
+Usage:
+{{ include "common.postgresql.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
+*/}}
+{{- define "common.postgresql.existingSecret" }}
+  {{- $service := .service }}
+  {{- $ctx := .ctx }}
+  {{- if not $ctx.Values.global.postgresql.enabled }}
+    {{- $existingSecret := "" }}
+    {{- with $service.postgresql }}
+      {{- if .existingSecret }}
+        {{- $existingSecret = .existingSecret }}
+      {{- end }}
+    {{- end }}
+    {{- if not $existingSecret }}
+      {{- with $ctx.Values.global.postgresql }}
+        {{- if .existingSecret }}
+          {{- $existingSecret = .existingSecret }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $existingSecret -}}
+  {{- end }}
+{{- end }}
+
+{{/*
 Generate PostgreSQL Connection Configuration
 
 Usage:
@@ -70,6 +106,34 @@ Returns: YAML configuration object with PostgreSQL connection parameters
       "timezone" (.timezone | default $postgresqlConfig.timezone)
       "sslmode" (.sslmode | default $postgresqlConfig.sslmode)
     ) $postgresqlConfig }}
+  {{- end }}
+
+  {{- /* existingSecret: pull real connection values from the referenced Secret so probes
+       hit the right DB instead of whatever global.postgresql.external.* is set to. */}}
+  {{- $existingSecret := include "common.postgresql.existingSecret" (dict "ctx" $ctx "service" $service) }}
+  {{- if $existingSecret }}
+    {{- $secretData := (lookup "v1" "Secret" $ctx.Release.Namespace $existingSecret).data | default dict }}
+    {{- $realHost := dig "POSTGRES_HOST" "" $secretData | b64dec }}
+    {{- $realPort := dig "POSTGRES_PORT" "" $secretData | b64dec }}
+    {{- $realUser := dig "POSTGRES_USER" "" $secretData | b64dec }}
+    {{- $realPass := dig "POSTGRES_PASSWORD" "" $secretData | b64dec }}
+    {{- $realSSL := dig "POSTGRES_SSLMODE" "" $secretData | b64dec }}
+    {{- if $realHost }}
+      {{- $portValue := $postgresqlConfig.port }}
+      {{- if $realPort }}
+        {{- $parsed := $realPort | atoi }}
+        {{- if $parsed }}{{ $portValue = $parsed }}{{ end }}
+      {{- end }}
+      {{- $postgresqlConfig = dict
+        "host" $realHost
+        "port" $portValue
+        "user" (or $realUser $postgresqlConfig.user)
+        "password" (or $realPass $postgresqlConfig.password)
+        "database" $postgresqlConfig.database
+        "timezone" $postgresqlConfig.timezone
+        "sslmode" (or $realSSL $postgresqlConfig.sslmode)
+      }}
+    {{- end }}
   {{- end }}
 
   {{- /* Validate required configurations */}}

--- a/charts/common/templates/_redis.tpl
+++ b/charts/common/templates/_redis.tpl
@@ -4,6 +4,38 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{/*
+Resolve the name of the Secret that supplies the Redis connection.
+
+Resolution order: service-level redis.existingSecret > global.redis.existingSecret.
+Only honored when global.redis.enabled=false. When set, the connection is resolved
+from the Secret's REDIS_* keys (REDIS_HOST/REDIS_PORT/REDIS_PASSWORD, optional
+REDIS_USER/REDIS_DATABASE) via lookup.
+
+Usage:
+{{ include "common.redis.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
+*/}}
+{{- define "common.redis.existingSecret" }}
+  {{- $service := .service }}
+  {{- $ctx := .ctx }}
+  {{- if not $ctx.Values.global.redis.enabled }}
+    {{- $existingSecret := "" }}
+    {{- with $service.redis }}
+      {{- if .existingSecret }}
+        {{- $existingSecret = .existingSecret }}
+      {{- end }}
+    {{- end }}
+    {{- if not $existingSecret }}
+      {{- with $ctx.Values.global.redis }}
+        {{- if .existingSecret }}
+          {{- $existingSecret = .existingSecret }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $existingSecret -}}
+  {{- end }}
+{{- end }}
+
+{{/*
 Generate Redis Connection Configuration
 
 Usage:
@@ -63,6 +95,31 @@ Returns: YAML configuration object with Redis connection parameters
       "user" (.user | default $redisConfig.user)
       "password" (.password | default $redisConfig.password)
     ) $redisConfig }}
+  {{- end }}
+
+  {{- /* existingSecret: pull real connection values from the referenced Secret. */}}
+  {{- $existingSecret := include "common.redis.existingSecret" (dict "ctx" $ctx "service" $service) }}
+  {{- if $existingSecret }}
+    {{- $secretData := (lookup "v1" "Secret" $ctx.Release.Namespace $existingSecret).data | default dict }}
+    {{- $realHost := dig "REDIS_HOST" "" $secretData | b64dec }}
+    {{- $realPort := dig "REDIS_PORT" "" $secretData | b64dec }}
+    {{- $realPass := dig "REDIS_PASSWORD" "" $secretData | b64dec }}
+    {{- $realUser := dig "REDIS_USER" "" $secretData | b64dec }}
+    {{- $realDB := dig "REDIS_DATABASE" "" $secretData | b64dec }}
+    {{- if $realHost }}
+      {{- $portValue := $redisConfig.port }}
+      {{- if $realPort }}
+        {{- $parsed := $realPort | atoi }}
+        {{- if $parsed }}{{ $portValue = $parsed }}{{ end }}
+      {{- end }}
+      {{- $redisConfig = dict
+        "host" $realHost
+        "port" $portValue
+        "database" (or $realDB $redisConfig.database)
+        "user" (or $realUser $redisConfig.user)
+        "password" (or $realPass $redisConfig.password)
+      }}
+    {{- end }}
   {{- end }}
 
   {{- /* Validate required configurations */}}

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
+  version: 0.2.8
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -16,13 +16,13 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.4.2
+  version: 2.4.3
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
-  version: 2.4.1
+  version: 2.4.2
 - name: csgship
   repository: https://charts.opencsg.com/csghub
-  version: 0.4.4
+  version: 0.4.5
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
@@ -31,9 +31,9 @@ dependencies:
   version: 1.7.5
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
-  version: 0.6.8
+  version: 0.6.9
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:4267e059a959bb79018a809c6321fa677aa24be9656aba4a824a8991bc7ebaf0
-generated: "2026-08-31T14:18:45.662995+08:00"
+digest: sha256:faebcea935f4c38e781b6968b5f5c65d95e300134c506f11c203c20dccde4cdf
+generated: "2026-09-04T11:11:03.365712+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.2
+version: 2.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14
@@ -52,15 +52,15 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.4.2
+    version: 2.4.3
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow
-    version: 2.4.1
+    version: 2.4.2
     repository: https://charts.opencsg.com/csghub
     condition: dataflow.enabled
   - name: csgship
-    version: 0.4.4
+    version: 0.4.5
     repository: https://charts.opencsg.com/csghub
     condition: csgship.enabled
   - name: memmachine
@@ -73,7 +73,7 @@ dependencies:
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
   - name: agentichub
-    version: 0.6.8
+    version: 0.6.9
     repository: https://charts.opencsg.com/csghub
     condition: agentichub.enabled
   - name: superset

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -86,6 +86,11 @@ global:
       # password: ""                # Database password
       # timezone: "Etc/UTC"         # Database timezone
       # sslmode: "prefer"           # SSL mode
+    ## Reference an existing Secret containing POSTGRES_HOST/POSTGRES_PORT/
+    ## POSTGRES_USER/POSTGRES_PASSWORD/[POSTGRES_SSLMODE]. Only honored when
+    ## enabled=false. The Secret must be provisioned in the release namespace
+    ## before helm install/upgrade runs.
+    existingSecret: ""
 
   ## Redis configuration
   redis:
@@ -96,6 +101,9 @@ global:
       # host: "<redis_host>"        # Redis server hostname or IP
       # port: 6379                  # Redis port number
       # password: ""                # Redis authentication password
+    ## Reference an existing Secret containing REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/
+    ## [REDIS_USER]/[REDIS_DATABASE]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## Object storage configuration
   objectStore:
@@ -110,6 +118,10 @@ global:
       # encrypt: false            # Enable server-side encryption
       # secure: false             # Use HTTPS for connections
       # pathStyle: true           # Use path-style addressing
+    ## Reference an existing Secret containing OBJECT_STORE_ENDPOINT/
+    ## OBJECT_STORE_ACCESS_KEY/OBJECT_STORE_SECRET_KEY/[OBJECT_STORE_REGION]/
+    ## [OBJECT_STORE_BUCKET]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## Container Registry configuration
   registry:
@@ -134,6 +146,9 @@ global:
       # port: 8075                  # Gitaly port number
       # token: ""                   # Authentication token
       # storage: "default"          # Storage name for repositories
+    ## Reference an existing Secret containing GITALY_HOST/GITALY_PORT/GITALY_TOKEN/
+    ## [GITALY_STORAGE]/[GITALY_SCHEME]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## Dataflow configuration
   dataflow:

--- a/charts/csgship/Chart.lock
+++ b/charts/csgship/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
+  version: 0.2.8
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:3b0d7ab7cce22ad31a16f60b1dfa64feec6b4476bb14c1c15ee848e01a70eba3
-generated: "2026-08-31T14:17:54.323127+08:00"
+digest: sha256:016c7c312b2c9c2cffd6695b7d1a42a4226dbcf6f9994bed753c939b0520fa19
+generated: "2026-09-04T10:51:39.546866+08:00"

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,7 +33,7 @@ appVersion: v0.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/csgship/values.yaml
+++ b/charts/csgship/values.yaml
@@ -70,6 +70,10 @@ global:
       # password: ""                # Database password
       # timezone: "Etc/UTC"         # Database timezone
       # sslmode: "prefer"           # SSL mode
+    ## Reference an existing Secret containing POSTGRES_HOST/POSTGRES_PORT/
+    ## POSTGRES_USER/POSTGRES_PASSWORD/[POSTGRES_SSLMODE]. Only honored when
+    ## enabled=false. The Secret must be provisioned in the release namespace.
+    existingSecret: ""
 
   ## Redis configuration
   redis:
@@ -80,6 +84,9 @@ global:
       # host: "<redis_host>"        # Redis server hostname or IP
       # port: 6379                  # Redis port number
       # password: ""                # Redis authentication password
+    ## Reference an existing Secret containing REDIS_HOST/REDIS_PORT/REDIS_PASSWORD/
+    ## [REDIS_USER]/[REDIS_DATABASE]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## subChart deployment context
   chartContext:

--- a/charts/dataflow/Chart.lock
+++ b/charts/dataflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
+  version: 0.2.8
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:3b0d7ab7cce22ad31a16f60b1dfa64feec6b4476bb14c1c15ee848e01a70eba3
-generated: "2026-08-31T14:19:43.947709+08:00"
+digest: sha256:016c7c312b2c9c2cffd6695b7d1a42a4226dbcf6f9994bed753c939b0520fa19
+generated: "2026-09-04T10:52:12.390967+08:00"

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.1
+version: 2.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/dataflow/values.yaml
+++ b/charts/dataflow/values.yaml
@@ -70,6 +70,10 @@ global:
       # password: ""                # Database password
       # timezone: "Etc/UTC"         # Database timezone
       # sslmode: "prefer"           # SSL mode
+    ## Reference an existing Secret containing POSTGRES_HOST/POSTGRES_PORT/
+    ## POSTGRES_USER/POSTGRES_PASSWORD/[POSTGRES_SSLMODE]. Only honored when
+    ## enabled=false. The Secret must be provisioned in the release namespace.
+    existingSecret: ""
 
   ## SubChart deployment context
   chartContext:

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.7
+  version: 0.2.8
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.5.4
-digest: sha256:ad2ff4e3ff1200426d42563c48a489309c1d0889e577efb1aef3399bcefe2713
-generated: "2026-08-31T14:20:27.933857+08:00"
+digest: sha256:5d7b64dfcd868d75fb4dbc2a7f50ab20164deb811d859c0fff5f56a67f17eaab
+generated: "2026-09-04T10:53:01.649738+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.2
+version: 2.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -36,7 +36,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.7
+    version: 0.2.8
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14


### PR DESCRIPTION
## Background

Issue #672: move the database/Redis/MinIO/Gitaly connection credentials out of plaintext rendered manifests. Introduces an `existingSecret` mechanism so users can keep these credentials in a Secret they pre-create; the chart resolves them at install time via `lookup`, keeping plaintext out of ConfigMaps and diff output.

## Implementation

Appends a lookup block to the end of the four `_*.tpl` helpers (`charts/common/templates/`):

- `common.postgresql.existingSecret` / `_redis.existingSecret` / `_gitaly.existingSecret` / `_objectStore.existingSecret`: resolve service-level > global-level secret name, returning non-empty only when `global.{X}.enabled=false`
- `common.{X}.config`: once the secret is resolved, `lookup "v1" "Secret" $ns $name` reads the data, b64decodes the matching uppercase keys (POSTGRES_HOST/PORT/USER/PASSWORD/SSLMODE, REDIS_HOST/PORT/PASSWORD/USER/DATABASE, OBJECT_STORE_ENDPOINT/ACCESS_KEY/SECRET_KEY/REGION/BUCKET, GITALY_HOST/PORT/TOKEN/STORAGE/SCHEME), and rebuilds the final config dict from those values

`charts/common/Chart.yaml` bumped to 0.2.8; the six parent charts' `Chart.yaml` + `Chart.lock` updated accordingly.

## Precedence chain (verified)

```
default (chart-managed internal)
  <  global.{X}.external.*
    <  service.{X}.*           (e.g., server.postgresql.password)
      <  global.{X}.existingSecret lookup
        <  service.{X}.existingSecret lookup   (for that service)
```

## Real install test (pg/redis/minio via docker compose, three secrets pre-created in k8s)

| RUN | Config | Verified |
|---|---|---|
| A | three global secrets | DSN uses external pg, REVISION=1 deployed |
| B | three global secrets + server/portal svc secrets (pointing at marker services on different ports) | server pg 55441 / redis 6380 / portal s3 59999 (svcmarker); svc overrides global in all cases, REVISION=2 deployed |
| C | all global.external.* decoys + three global secrets | DSN/Redis/MinIO all use the real secret values, all decoys dropped |
| D | only global.external.*, no secrets | the four values (host/port/password/accessKey) pass through correctly |
| E | real global.external.* + server.{postgresql,redis}.* set to svc_decoy_* | server DSN password=svc_decoy_pgpass, redis password=svc_decoy_redispass; portal DSN still uses the global pgsecret (unpolluted) |

All five scenarios verified by reading `data.*` from the deployed release's `csghub-core` ConfigMap directly.

## Note (unrelated to this issue)

After each `helm uninstall`, `kubectl replace` is needed to reset the agent-sandbox CRD's `spec.conversion.webhook.clientConfig.service.namespace` back to `agent-sandbox-system`. The agent-sandbox chart's `chart.sh` applies its sed substitution to the `templates/` directory, but the CRD has already been `mv`'d to `crds/`, so the namespace field keeps the literal value; at runtime the agent-sandbox-controller starts with `--webhook-namespace={{ .Release.Namespace }}` and rewrites it via server-side apply. Suggest fixing the agent-sandbox chart packaging script in a separate PR.
