### PR TITLE
feat(csghub): rename temporal-worker deployment to executor and add repository deletion-worker

### DIFF
--- a/charts/csghub/templates/csghub/executor/deployment.yaml
+++ b/charts/csghub/templates/csghub/executor/deployment.yaml
@@ -3,7 +3,7 @@ Copyright OpenCSG, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
-{{- $service := include "common.service" (dict "ctx" . "service" "temporalWorker") | fromYaml }}
+{{- $service := include "common.service" (dict "ctx" . "service" "executor") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
@@ -62,7 +62,7 @@ spec:
       initContainers:
         {{- include "wait-for-server" . | nindent 8 }}
       containers:
-        - name: {{ $service.name }}
+        - name: temporal-worker
           image: {{ include "common.image" (list . $serverImage) }}
           imagePullPolicy: {{ or $serverImage.pullPolicy .Values.global.image.pullPolicy }}
           command:
@@ -117,6 +117,16 @@ spec:
           {{- if $service.tty }}
           tty: {{ $service.tty }}
           {{- end }}
+        - name: deletion-worker
+          image: {{ include "common.image" (list . $serverImage) }}
+          imagePullPolicy: {{ or $serverImage.pullPolicy .Values.global.image.pullPolicy }}
+          command:
+            - "/starhub-bin/starhub"
+            - "repository"
+            - "deletion-worker"
+          envFrom:
+            - configMapRef:
+                name: {{ include "common.names.custom" (list . "core") }}
       volumes:
         {{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
         - name: casdoor-init-certs

--- a/charts/csghub/tests/executor-deployment_test.yaml
+++ b/charts/csghub/tests/executor-deployment_test.yaml
@@ -1,12 +1,13 @@
-# Test suite for the CSGHub Temporal Worker Deployment.
+# Test suite for the CSGHub Executor Deployment.
 #
-# The Deployment runs the temporal-worker module of the server image, mounting
-# the casdoor certs Secret. It always renders because the built-in temporal
-# worker has no enable switch.
+# The Deployment runs the temporal-worker launch module plus a repository
+# deletion-worker sidecar, both from the ee server image and reading the core
+# ConfigMap. The main container mounts the casdoor certs Secret. It always
+# renders because the built-in executor has no enable switch.
 
-suite: Test Temporal Worker Deployment
+suite: Test Executor Deployment
 templates:
-  - csghub/temporal/deployment.yaml
+  - csghub/executor/deployment.yaml
 release:
   name: csghub
   namespace: csghub
@@ -14,19 +15,19 @@ values:
   - values.yaml
 tests:
   - it: renders the Deployment metadata and spec defaults
-    template: csghub/temporal/deployment.yaml
+    template: csghub/executor/deployment.yaml
     asserts:
       - isKind:
           of: Deployment
       - equal:
           path: metadata.name
-          value: "csghub-temporal-worker"
+          value: "csghub-executor"
       - equal:
           path: metadata.namespace
           value: "csghub"
       - equal:
           path: metadata.labels["app.kubernetes.io/service"]
-          value: "temporal-worker"
+          value: "executor"
       - equal:
           path: metadata.annotations["reloader.stakater.com/auto"]
           value: "true"
@@ -35,10 +36,10 @@ tests:
           value: 1
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/service"]
-          value: "temporal-worker"
+          value: "executor"
 
   - it: runs the temporal-worker launch command from the ee server image
-    template: csghub/temporal/deployment.yaml
+    template: csghub/executor/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].name
@@ -57,8 +58,31 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].ports
 
+  - it: runs the repository deletion-worker as a second container
+    template: csghub/executor/deployment.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: "deletion-worker"
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: "docker.io/opencsghq/csghub-server:v2.4.0-ee"
+      - equal:
+          path: spec.template.spec.containers[1].command
+          value: ["/starhub-bin/starhub", "repository", "deletion-worker"]
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            configMapRef:
+              name: csghub-core
+      - notExists:
+          path: spec.template.spec.containers[1].volumeMounts
+
   - it: mounts the casdoor certs Secret for JWT signing
-    template: csghub/temporal/deployment.yaml
+    template: csghub/executor/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
@@ -86,14 +110,14 @@ tests:
           value: "tls.key"
 
   - it: waits for the server in the init container
-    template: csghub/temporal/deployment.yaml
+    template: csghub/executor/deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: "wait-for-server"
 
   - it: overrides the image registry when registryPolicy is force
-    template: csghub/temporal/deployment.yaml
+    template: csghub/executor/deployment.yaml
     set:
       global:
         image:

--- a/charts/csghub/tests/values.yaml
+++ b/charts/csghub/tests/values.yaml
@@ -210,7 +210,7 @@ dataviewer: {}
 fedap: {}
 trustregistry: {}
 mirror: {}
-temporalWorker: {}
+executor: {}
 
 tags:
   dependencies: false

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -568,8 +568,8 @@ trustregistry: {}
 ## Mirror service configuration
 mirror: {}
 
-## temporalWorker configuration
-temporalWorker: {}
+## Executor service configuration
+executor: {}
 
 ## Helm tags to control sub-chart dependencies
 ## Set dependencies: false to disable reloader, prometheus, gateway-helm subcharts


### PR DESCRIPTION
## Summary

Renames the built-in csghub temporal worker Deployment to executor and adds a repository deletion-worker sidecar.

- **Deployment / service rename**: `csghub/templates/csghub/{temporal => executor}/deployment.yaml`, service label and values key `temporalWorker` -> `executor` (`charts/csghub/values.yaml`, `charts/csghub/tests/values.yaml`), Deployment name `csghub-temporal-worker` -> `csghub-executor`
- **Main container `temporal-worker`**: startup command stays `/starhub-bin/starhub temporal-worker launch`, still mounts the tls.crt / tls.key projected from the casdoor-init Secret, envFrom `csghub-core`
- **New sidecar `deletion-worker`**: `/starhub-bin/starhub repository deletion-worker`, also envFrom `csghub-core`, reusing the same ee server image
- **Tests**: `{temporal-worker => executor}-deployment_test.yaml` renamed to match, with added deletion-worker container assertions (including `lengthEqual: 2`)

## Files

- `charts/csghub/templates/csghub/{temporal => executor}/deployment.yaml` (+12/-2)
- `charts/csghub/tests/{temporal-worker => executor}-deployment_test.yaml` (+38/-14)
- `charts/csghub/values.yaml` (executor values key)
- `charts/csghub/tests/values.yaml` (executor values key)

## Test

`helm unittest charts/csghub --with-subchart=false`: Executor Deployment suite 6/6 pass
