### PR TITLE
chore(csghub): temporarily disable executor deletion-worker sidecar

### DIFF
--- a/charts/csghub/templates/csghub/executor/deployment.yaml
+++ b/charts/csghub/templates/csghub/executor/deployment.yaml
@@ -117,6 +117,11 @@ spec:
           {{- if $service.tty }}
           tty: {{ $service.tty }}
           {{- end }}
+        {{- /*
+TODO: temporarily disabled; restore the deletion-worker sidecar below in
+the next release by removing this `if false` guard.
+*/}}
+        {{- if false }}
         - name: deletion-worker
           image: {{ include "common.image" (list . $serverImage) }}
           imagePullPolicy: {{ or $serverImage.pullPolicy .Values.global.image.pullPolicy }}
@@ -127,6 +132,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.custom" (list . "core") }}
+        {{- end }}
       volumes:
         {{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
         - name: casdoor-init-certs

--- a/charts/csghub/tests/executor-deployment_test.yaml
+++ b/charts/csghub/tests/executor-deployment_test.yaml
@@ -1,9 +1,9 @@
 # Test suite for the CSGHub Executor Deployment.
 #
-# The Deployment runs the temporal-worker launch module plus a repository
-# deletion-worker sidecar, both from the ee server image and reading the core
-# ConfigMap. The main container mounts the casdoor certs Secret. It always
-# renders because the built-in executor has no enable switch.
+# The Deployment runs the temporal-worker launch module. The repository
+# deletion-worker sidecar is currently wrapped in `{{- if false }}` and does
+# not render; re-enable the block and restore the deletion-worker assertions
+# in the next release.
 
 suite: Test Executor Deployment
 templates:
@@ -58,28 +58,15 @@ tests:
       - notExists:
           path: spec.template.spec.containers[0].ports
 
-  - it: runs the repository deletion-worker as a second container
+  - it: omits the deletion-worker sidecar (temporarily disabled)
     template: csghub/executor/deployment.yaml
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers
-          count: 2
+          count: 1
       - equal:
-          path: spec.template.spec.containers[1].name
-          value: "deletion-worker"
-      - equal:
-          path: spec.template.spec.containers[1].image
-          value: "docker.io/opencsghq/csghub-server:v2.5.0-ee"
-      - equal:
-          path: spec.template.spec.containers[1].command
-          value: ["/starhub-bin/starhub", "repository", "deletion-worker"]
-      - contains:
-          path: spec.template.spec.containers[1].envFrom
-          content:
-            configMapRef:
-              name: csghub-core
-      - notExists:
-          path: spec.template.spec.containers[1].volumeMounts
+          path: spec.template.spec.containers[0].name
+          value: "temporal-worker"
 
   - it: mounts the casdoor certs Secret for JWT signing
     template: csghub/executor/deployment.yaml


### PR DESCRIPTION
## Summary
- Wrap the executor deployment's deletion-worker sidecar in `{{- if false }}` with a TODO comment so it does not render in this release.
- Update the executor deployment test to assert only the temporal-worker container is rendered; restore the deletion-worker assertions in the next release.

## Notes
- To re-enable in the next release, remove the `{{- if false }}` guard in `charts/csghub/templates/csghub/executor/deployment.yaml` and flip the corresponding test in `charts/csghub/tests/executor-deployment_test.yaml` back to `count: 2`.