### PR TITLE
chore: bump agenticflow to ee-v0.6.5-2 and csghub chart to 2.5.0-rc.1

### DIFF
--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -130,7 +130,7 @@ agenticflow:
   image:
     # registry: "docker.io"
     repository: "opencsghq/agenticflow"
-    tag: "ee-v0.6.5-1"
+    tag: "ee-v0.6.5-2"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
 

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0
+version: 2.5.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
- bump agentichub agenticflow image tag from ee-v0.6.5-1 to ee-v0.6.5-2
- bump csghub chart version from 2.5.0 to 2.5.0-rc.1