### PR TITLE
feat(runner): add gpuModelLabel with snakecase dynamic keys and move from space to runner section

### DIFF
--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.5.0-rc.1
+  version: 2.5.0-rc.2
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
   version: 2.5.0-rc.1
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:8fe3e6c9dfbad27b0976e2e55d10ac96c9c2815a71838ed4b7e5cb120aa6f5a6
-generated: "2026-09-10T05:14:16.814646+08:00"
+digest: sha256:bb965ad9c0ec1c4829f939e597c75a940487bff1d6958eb0c65cb143a2787bc3
+generated: "2026-09-10T18:25:56.851366+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0-rc.2
+version: 2.5.0-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -52,7 +52,7 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.5.0-rc.1
+    version: 2.5.0-rc.2
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -298,9 +298,6 @@ data:
   STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $runnerSvc.space.pipIndexUrl | quote }}
   STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES: {{ $runnerSvc.space.deployTimeoutInMin | default 30 | quote }}
   STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL: {{ $runnerSvc.space.statusCheckInterval | default 10 | quote }}
-  {{- $typeLabel := $runnerSvc.space.gpuModelLabel.typeLabel }}
-  {{- $capacityLabel := $runnerSvc.space.gpuModelLabel.capacityLabel }}
-  STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
   STARHUB_SERVER_SPACE_SESSION_SECRET_KEY: {{ include "common.secret.value" (list . "space-session-secret-key" 40) | quote }}
 
   ## Server Configuration for Casdoor

--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -155,9 +155,6 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
           value: "30"
-      - equal:
-          path: data.STARHUB_SERVER_GPU_MODEL_LABEL
-          value: '[{"type_label": "nvidia.com/gpu.product", "capacity_label": "nvidia.com/gpu"}]'
       - matchRegex:
           path: data.OPENCSG_ACCOUNTING_NATS_URL
           pattern: "nats://natsadmin:.*@csghub-nats:4222"

--- a/charts/csghub/tests/values.yaml
+++ b/charts/csghub/tests/values.yaml
@@ -162,14 +162,15 @@ runner:
     interval: 60
     namespace: "spaces"
     mergingNamespace: "disable"
+    gpuModelLabel:
+      typeLabel: "nvidia.com/gpu.product"
+      capacityLabel: "nvidia.com/gpu"
+      memLabel: "nvidia.com/gpu.memory"
   model:
     deployTimeoutInMin: 60
   space:
     usePublicDomain: true
     pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"
-    gpuModelLabel:
-      typeLabel: "nvidia.com/gpu.product"
-      capacityLabel: "nvidia.com/gpu"
   knative:
     serving:
       domain: "example.com"

--- a/charts/csghub/tests/values.yaml
+++ b/charts/csghub/tests/values.yaml
@@ -166,6 +166,7 @@ runner:
       typeLabel: "nvidia.com/gpu.product"
       capacityLabel: "nvidia.com/gpu"
       memLabel: "nvidia.com/gpu.memory"
+      xpuType: "GPU"
   model:
     deployTimeoutInMin: 60
   space:

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -462,6 +462,7 @@ runner:
       typeLabel: "nvidia.com/gpu.product"  # GPU type label
       capacityLabel: "nvidia.com/gpu"      # GPU capacity label
       memLabel: "nvidia.com/gpu.memory"    # GPU memory label
+      xpuType: "GPU"                       # XPU type identifier
 
     # applicationEndpoint: ""            # Knative endpoint override (auto-detected if empty)
     # networkInterface: ""               # Host network interface for distributed inference

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -457,6 +457,12 @@ runner:
     namespace: "spaces"                  # Namespace for user-deployed workloads
     mergingNamespace: "disable"          # Namespace merging: multi, single, disable
 
+    ## GPU resource configuration
+    gpuModelLabel:
+      typeLabel: "nvidia.com/gpu.product"  # GPU type label
+      capacityLabel: "nvidia.com/gpu"      # GPU capacity label
+      memLabel: "nvidia.com/gpu.memory"    # GPU memory label
+
     # applicationEndpoint: ""            # Knative endpoint override (auto-detected if empty)
     # networkInterface: ""               # Host network interface for distributed inference
     # storageClassName: ""               # StorageClass for space persistent volumes
@@ -475,11 +481,6 @@ runner:
 
     # deployTimeoutInMin: 30           # Timeout (in minutes) for space deployment operations
     # buildTimeoutInMin: 30            # Timeout (in minutes) for space build operations
-
-    ## GPU resource configuration
-    gpuModelLabel:
-      typeLabel: "nvidia.com/gpu.product"  # GPU type label
-      capacityLabel: "nvidia.com/gpu"      # GPU capacity label
 
     # readinessDelaySeconds: 120       # Initial delay before readiness probe starts
     # readinessPeriodSeconds: 10       # Interval between readiness probe checks

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0-rc.1
+version: 2.5.0-rc.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -98,12 +98,14 @@ data:
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL: "300"
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL: {{ $statusTTL | quote }}
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS: {{ include "runner.kaniko.args" (dict "ctx" . "service" $service) | quote }}
+  {{- $gpuLabels := dict }}
+  {{- range $key, $value := $service.runner.gpuModelLabel }}
+    {{- $gpuLabels = set $gpuLabels ($key | snakecase) $value }}
+  {{- end }}
+  STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL: '[{{ $gpuLabels | mustToJson }}]'
 
   ## Runner Configuration for Argo
   STARHUB_SERVER_ARGO_SERVICE_ACCOUNT: {{ printf "%s-argo-workflow-executor" .Release.Name | quote }}
-  {{- $typeLabel := $service.space.gpuModelLabel.typeLabel }}
-  {{- $capacityLabel := $service.space.gpuModelLabel.capacityLabel }}
-  STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
   STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.model.deployTimeoutInMin | default 60 | quote }}
   ## Runner Configuration for Space Timeouts
   STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.space.deployTimeoutInMin | default 30 | quote }}

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -231,8 +231,8 @@ tests:
           path: data.STARHUB_SERVER_ARGO_SERVICE_ACCOUNT
           value: "csghub-argo-workflow-executor"
       - equal:
-          path: data.STARHUB_SERVER_GPU_MODEL_LABEL
-          value: '[{"type_label": "nvidia.com/gpu.product", "capacity_label": "nvidia.com/gpu"}]'
+          path: data.STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL
+          value: '[{"capacity_label":"nvidia.com/gpu","mem_label":"nvidia.com/gpu.memory","type_label":"nvidia.com/gpu.product"}]'
 
   ## ------------------------------------------------------------------
   ## Timeouts and readiness probes

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -232,7 +232,7 @@ tests:
           value: "csghub-argo-workflow-executor"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL
-          value: '[{"capacity_label":"nvidia.com/gpu","mem_label":"nvidia.com/gpu.memory","type_label":"nvidia.com/gpu.product"}]'
+          value: '[{"capacity_label":"nvidia.com/gpu","mem_label":"nvidia.com/gpu.memory","type_label":"nvidia.com/gpu.product","xpu_type":"GPU"}]'
 
   ## ------------------------------------------------------------------
   ## Timeouts and readiness probes

--- a/charts/runner/tests/values.yaml
+++ b/charts/runner/tests/values.yaml
@@ -94,6 +94,10 @@ runner:
   imageBuilderKanikoImage: ""
   imageBuilderStatusTTL: 300
   imageBuilderKanikoArgs: []
+  gpuModelLabel:
+    typeLabel: nvidia.com/gpu.product
+    capacityLabel: nvidia.com/gpu
+    memLabel: nvidia.com/gpu.memory
 
 ## Model deploy configuration
 model:
@@ -111,9 +115,6 @@ space:
   readinessDelaySeconds: 120
   readinessPeriodSeconds: 10
   readinessFailureThreshold: 3
-  gpuModelLabel:
-    typeLabel: nvidia.com/gpu.product
-    capacityLabel: nvidia.com/gpu
 
 ## Knative Serving configuration
 knative:

--- a/charts/runner/tests/values.yaml
+++ b/charts/runner/tests/values.yaml
@@ -98,6 +98,7 @@ runner:
     typeLabel: nvidia.com/gpu.product
     capacityLabel: nvidia.com/gpu
     memLabel: nvidia.com/gpu.memory
+    xpuType: GPU
 
 ## Model deploy configuration
 model:

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -120,6 +120,12 @@ runner:
   ## Allow CPU resource requests to be scheduled on GPU nodes
   allowCpuOnGpuNodes: false
 
+  ## GPU resource configuration
+  gpuModelLabel:
+    typeLabel: "nvidia.com/gpu.product"  # Kubernetes node label for GPU product type
+    capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
+    memLabel: "nvidia.com/gpu.memory"    # Kubernetes node label for GPU memory
+
   # Image builder management
   # imageBuilderGitImage: ""               # Override image builder Git image
   # imageBuilderKanikoImage: ""            # Override image builder Kaniko image
@@ -160,11 +166,6 @@ space:
 
   ## Timeout (in minutes) for space image build operations
   # buildTimeoutInMin: 30
-
-  ## GPU resource configuration
-  gpuModelLabel:
-    typeLabel: "nvidia.com/gpu.product"  # Kubernetes node label for GPU product type
-    capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
 
   ## Kubernetes readiness probe configuration for space pods (in seconds)
   # readinessDelaySeconds: 120              # Initial delay before readiness probe starts

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -125,6 +125,7 @@ runner:
     typeLabel: "nvidia.com/gpu.product"  # Kubernetes node label for GPU product type
     capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
     memLabel: "nvidia.com/gpu.memory"    # Kubernetes node label for GPU memory
+    xpuType: "GPU"                       # XPU type identifier
 
   # Image builder management
   # imageBuilderGitImage: ""               # Override image builder Git image


### PR DESCRIPTION
## Summary

- Add `gpuModelLabel` config block under `runner.runner` in values.yaml
- Render `STARHUB_SERVER_RUNNER_GPU_MODEL_LABEL` from `gpuModelLabel` using `snakecase` for automatic key generation
- Move `gpuModelLabel` from `space:` to `runner:` section across runner and csghub umbrella values (with test fixtures)
- Drop the duplicate hardcoded `STARHUB_SERVER_GPU_MODEL_LABEL` in the csghub umbrella configmap template (now produced by the runner subchart)
- Add `memLabel` and `xpuType` fields to `gpuModelLabel`
- Bump chart versions

## Test plan

- [x] `helm unittest charts/runner` — 147/147 pass
- [x] `helm unittest charts/csghub --with-subchart=false` — 409/409 pass
- [x] `helm upgrade --install` with default values produces valid ConfigMap