### PR TITLE
feat(csghub): add configurable gitaly jwtSecret for gitlab-shell JWT …

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -18,7 +18,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/_gitaly.tpl
+++ b/charts/common/templates/_gitaly.tpl
@@ -9,7 +9,7 @@ Resolve the name of the Secret that supplies the Gitaly connection.
 Resolution order: service-level gitaly.existingSecret > global.gitaly.existingSecret.
 Only honored when global.gitaly.enabled=false. When set, the connection is resolved
 from the Secret's GITALY_* keys (GITALY_HOST/GITALY_PORT/GITALY_TOKEN, optional
-GITALY_STORAGE/GITALY_SCHEME) via lookup.
+GITALY_STORAGE/GITALY_SCHEME/GITALY_JWT_SECRET) via lookup.
 
 Usage:
 {{ include "common.gitaly.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
@@ -62,6 +62,7 @@ Returns: YAML configuration object with Gitaly connection parameters
     "storage" (dig "storage" "default" $gitalySvc)
     "token" (include "common.secret.password" (list $ctx (printf "%s.password" $gitalySvc.name) 32))
     "scheme" "tcp"
+    "jwtSecret" "signing-key"
   }}
 
   {{- /* If internal Gitaly is enabled and secret exists, use existing token */}}
@@ -82,6 +83,7 @@ Returns: YAML configuration object with Gitaly connection parameters
         "storage" (.storage | default $gitalyConfig.storage)
         "token" (.token | default $gitalyConfig.token)
         "scheme" (.scheme | default $gitalyConfig.scheme)
+        "jwtSecret" (.jwtSecret | default $gitalyConfig.jwtSecret)
       ) $gitalyConfig }}
     {{- end }}
   {{- end }}
@@ -94,6 +96,7 @@ Returns: YAML configuration object with Gitaly connection parameters
       "storage" (.storage | default $gitalyConfig.storage)
       "token" (.token | default $gitalyConfig.token)
       "scheme" (.scheme | default $gitalyConfig.scheme)
+      "jwtSecret" (.jwtSecret | default $gitalyConfig.jwtSecret)
     ) $gitalyConfig }}
   {{- end }}
 
@@ -106,6 +109,7 @@ Returns: YAML configuration object with Gitaly connection parameters
     {{- $realToken := dig "GITALY_TOKEN" "" $secretData | b64dec }}
     {{- $realStorage := dig "GITALY_STORAGE" "" $secretData | b64dec }}
     {{- $realScheme := dig "GITALY_SCHEME" "" $secretData | b64dec }}
+    {{- $realJwtSecret := dig "GITALY_JWT_SECRET" "" $secretData | b64dec }}
     {{- if $realHost }}
       {{- $portValue := $gitalyConfig.port }}
       {{- if $realPort }}
@@ -118,6 +122,7 @@ Returns: YAML configuration object with Gitaly connection parameters
         "storage" (or $realStorage $gitalyConfig.storage)
         "token" (or $realToken $gitalyConfig.token)
         "scheme" (or $realScheme $gitalyConfig.scheme)
+        "jwtSecret" (or $realJwtSecret $gitalyConfig.jwtSecret)
       }}
     {{- end }}
   {{- end }}

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.3.1
+  version: 0.3.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:bb965ad9c0ec1c4829f939e597c75a940487bff1d6958eb0c65cb143a2787bc3
-generated: "2026-09-10T18:25:56.851366+08:00"
+digest: sha256:aae86f94b78398ee5c91a580e4d71163e0585762efb949997f9f734dbd7ef6b1
+generated: "2026-09-11T12:29:52.642959+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v2.5.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.3.1
+    version: 0.3.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -283,6 +283,7 @@ data:
   STARHUB_SERVER_GITALY_SERVER_SOCKET: {{ printf "%s://%s:%v" $serverGitConfig.scheme $serverGitConfig.host $serverGitConfig.port | quote }}
   STARHUB_SERVER_GITALY_TOKEN: {{ $serverGitConfig.token | quote }}
   STARHUB_SERVER_GITALY_STORAGE: {{ $serverGitConfig.storage | quote }}
+  STARHUB_SERVER_GITALY_JWT_SECRET: {{ $serverGitConfig.jwtSecret | quote }}
   {{- $domain := include "common.domain.csghub" . }}
   {{- $defaultPort := ternary "30022" "22" (eq (dig "service" "type" "LoadBalancer" .Values.global.gateway) "NodePort") }}
   {{- $port := toString ($serverSvc.gitlabShell.sshPort | default $defaultPort) }}

--- a/charts/csghub/templates/gitlab-shell/configmap.yaml
+++ b/charts/csghub/templates/gitlab-shell/configmap.yaml
@@ -63,7 +63,7 @@ data:
 
     # The secret field supersedes the secret_file, and if set that
     # file will not be read.
-    secret: "signing-key"
+    secret: {{ $gitalyConfig.jwtSecret | quote }}
 
     # Log file.
     # Default is gitlab-shell.log in the root directory.

--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -128,6 +128,9 @@ tests:
           path: data.STARHUB_SERVER_GITALY_SERVER_SOCKET
           pattern: "tcp://csghub-gitaly:8075"
       - equal:
+          path: data.STARHUB_SERVER_GITALY_JWT_SECRET
+          value: "signing-key"
+      - equal:
           path: data.STARHUB_SERVER_SSH_DOMAIN
           value: "git@csghub.example.com"
       - equal:
@@ -486,6 +489,7 @@ tests:
             port: 8076
             token: "Gitaly2025"
             storage: "gitaly"
+            jwtSecret: "GitalyJWT2025"
         dataflow:
           enabled: false
           external:
@@ -561,6 +565,9 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_GITALY_STORAGE
           value: "gitaly"
+      - equal:
+          path: data.STARHUB_SERVER_GITALY_JWT_SECRET
+          value: "GitalyJWT2025"
       - equal:
           path: data.OPENCSG_DATAFLOW_SERVER_HOST
           value: "http://10.6.0.14"

--- a/charts/csghub/tests/gitlab-shell-configmap_test.yaml
+++ b/charts/csghub/tests/gitlab-shell-configmap_test.yaml
@@ -40,3 +40,24 @@ tests:
       - matchRegex:
           path: data["config.yml"]
           pattern: 'listen: "\[::\]:22"'
+      - matchRegex:
+          path: data["config.yml"]
+          pattern: 'secret: "signing-key"'
+
+  - it: uses the external gitaly jwt secret when built-in gitaly is disabled
+    template: gitlab-shell/configmap.yaml
+    documentIndex: 0
+    set:
+      global:
+        gitaly:
+          enabled: false
+          external:
+            host: "10.6.0.13"
+            port: 8076
+            token: "Gitaly2025"
+            storage: "gitaly"
+            jwtSecret: "GitalyJWT2025"
+    asserts:
+      - matchRegex:
+          path: data["config.yml"]
+          pattern: 'secret: "GitalyJWT2025"'

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -146,8 +146,9 @@ global:
       # port: 8075                  # Gitaly port number
       # token: ""                   # Authentication token
       # storage: "default"          # Storage name for repositories
+      # jwtSecret: "signing-key"    # Shared secret for gitlab-shell <-> server JWT auth
     ## Reference an existing Secret containing GITALY_HOST/GITALY_PORT/GITALY_TOKEN/
-    ## [GITALY_STORAGE]/[GITALY_SCHEME]. Only honored when enabled=false.
+    ## [GITALY_STORAGE]/[GITALY_SCHEME]/[GITALY_JWT_SECRET]. Only honored when enabled=false.
     existingSecret: ""
 
   ## Dataflow configuration


### PR DESCRIPTION
## Background

The `secret: "signing-key"` in the `gitlab-shell` configmap was a hardcoded string, so an external Gitaly could not use a custom signing key. It was out of step with the already-configurable `host/port/token/storage`, leaving the JWT check between server and shell reusing the same weak key across environments.

## Changes

- `common.gitaly.config`: new `jwtSecret` field, resolved in the same order as the existing `token/storage/scheme` — explicit service value first, then `global.gitaly.external.jwtSecret`, then the `GITALY_JWT_SECRET` key in `existingSecret`, defaulting to `"signing-key"`.
- `charts/csghub/templates/csghub/configmap.yaml`: new `STARHUB_SERVER_GITALY_JWT_SECRET` env var.
- `charts/csghub/templates/gitlab-shell/configmap.yaml`: hardcoded `secret: "signing-key"` -> `{{ $gitalyConfig.jwtSecret | quote }}`.
- `values.yaml`: document the `jwtSecret` field in comments; add `GITALY_JWT_SECRET` to the `existingSecret` docs.
- Unit tests: default and custom values (one set each for the csghub configmap and the gitlab-shell configmap).
- `common` chart 0.3.1 -> 0.3.2, with `csghub` Chart.lock updated.

## Compatibility

Defaults are unchanged; deployments without `jwtSecret` behave exactly as before.
