### PR TITLE
feat(common): add existingSecret support for container registry

### DIFF
--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -143,6 +143,7 @@ agenticflow:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_agenticflow"       # Database name
@@ -153,6 +154,7 @@ agenticflow:
 
   ## Redis configuration
   redis: {}
+    # existingSecret: ""                   # Overrides the global redis.existingSecret when set
     # host: "<redis_host>"                 # Redis server hostname or IP
     # port: 6379                           # Redis port number
     # password: ""                         # Redis authentication password

--- a/charts/common/templates/_registry.tpl
+++ b/charts/common/templates/_registry.tpl
@@ -5,6 +5,38 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{/*
+Resolve the name of the Secret that supplies the container registry connection.
+
+Resolution order: service-level registry.existingSecret > global.registry.existingSecret.
+Only honored when global.registry.enabled=false. When set, the connection is resolved
+from the Secret's REGISTRY_* keys (REGISTRY_HOST, optional REGISTRY_REPOSITORY/
+REGISTRY_USERNAME/REGISTRY_PASSWORD) via lookup.
+
+Usage:
+{{ include "common.registry.existingSecret" (dict "ctx" . "service" .Values.servicename) }}
+*/}}
+{{- define "common.registry.existingSecret" }}
+  {{- $service := .service }}
+  {{- $ctx := .ctx }}
+  {{- if not $ctx.Values.global.registry.enabled }}
+    {{- $existingSecret := "" }}
+    {{- with $service.registry }}
+      {{- if .existingSecret }}
+        {{- $existingSecret = .existingSecret }}
+      {{- end }}
+    {{- end }}
+    {{- if not $existingSecret }}
+      {{- with $ctx.Values.global.registry }}
+        {{- if .existingSecret }}
+          {{- $existingSecret = .existingSecret }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- $existingSecret -}}
+  {{- end }}
+{{- end }}
+
+{{/*
 Generate Registry Configuration
 
 Usage:
@@ -18,6 +50,10 @@ Configuration priority:
 1. Internal registry (if enabled)
 2. Service-level external registry (override global)
 3. Global external registry
+
+When global.registry.enabled=false and a registry.existingSecret is configured
+(service-level > global), the connection is taken from that Secret's REGISTRY_*
+keys, overriding the values above.
 
 Returns: YAML configuration object with registry parameters
 */}}
@@ -71,6 +107,25 @@ Returns: YAML configuration object with registry parameters
     ) $registryConfig }}
     {{- if hasKey . "insecure" }}
       {{- $registryConfig = set $registryConfig "insecure" .insecure }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* existingSecret: pull real connection values from the referenced Secret. */}}
+  {{- $existingSecret := include "common.registry.existingSecret" (dict "ctx" $ctx "service" $service) }}
+  {{- if $existingSecret }}
+    {{- $secretData := (lookup "v1" "Secret" $ctx.Release.Namespace $existingSecret).data | default dict }}
+    {{- $realRegistry := dig "REGISTRY_HOST" "" $secretData | b64dec }}
+    {{- $realRepository := dig "REGISTRY_REPOSITORY" "" $secretData | b64dec }}
+    {{- $realUsername := dig "REGISTRY_USERNAME" "" $secretData | b64dec }}
+    {{- $realPassword := dig "REGISTRY_PASSWORD" "" $secretData | b64dec }}
+    {{- if $realRegistry }}
+      {{- $registryConfig = dict
+        "registry" $realRegistry
+        "repository" (or $realRepository $registryConfig.repository)
+        "username" (or $realUsername $registryConfig.username)
+        "password" (or $realPassword $registryConfig.password)
+        "insecure" $registryConfig.insecure
+      }}
     {{- end }}
   {{- end }}
 

--- a/charts/common/templates/fixtures/registry-existing-secret.yaml
+++ b/charts/common/templates/fixtures/registry-existing-secret.yaml
@@ -1,0 +1,2 @@
+{{/* Renders only the registry existingSecret name-resolution helper. */}}
+existingSecret: {{ include "common.registry.existingSecret" (dict "ctx" . "service" .Values) | quote }}

--- a/charts/common/tests/registry-config_test.yaml
+++ b/charts/common/tests/registry-config_test.yaml
@@ -73,3 +73,25 @@ tests:
       - equal:
           path: insecure
           value: false
+
+  - it: keeps the external registry values when the referenced secret is absent
+    set:
+      global:
+        registry:
+          existingSecret: "global-reg-secret"
+    asserts:
+      - equal:
+          path: registry
+          value: "registry.example.com"
+      - equal:
+          path: repository
+          value: "csghub"
+      - equal:
+          path: username
+          value: "reg-user"
+      - equal:
+          path: password
+          value: "reg-pass"
+      - equal:
+          path: insecure
+          value: true

--- a/charts/common/tests/registry-existing-secret_test.yaml
+++ b/charts/common/tests/registry-existing-secret_test.yaml
@@ -1,0 +1,57 @@
+# Test suite for the common.registry.existingSecret helper.
+#
+# Renders the name-resolution helper through
+# templates/fixtures/registry-existing-secret.yaml. Baseline values come from
+# tests/values.yaml (global.registry.enabled=false). The helper is only honored
+# in external mode; the referenced Secret's contents are resolved separately in
+# common.registry.config via lookup, which helm-unittest cannot mock.
+
+suite: Test common.registry.existingSecret
+templates:
+  - templates/fixtures/registry-existing-secret.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: returns empty when no existingSecret is configured
+    asserts:
+      - equal:
+          path: existingSecret
+          value: ""
+
+  - it: returns the global existingSecret in external mode
+    set:
+      global:
+        registry:
+          existingSecret: "global-reg-secret"
+    asserts:
+      - equal:
+          path: existingSecret
+          value: "global-reg-secret"
+
+  - it: prefers the service-level existingSecret over the global one
+    set:
+      registry:
+        existingSecret: "service-reg-secret"
+      global:
+        registry:
+          existingSecret: "global-reg-secret"
+    asserts:
+      - equal:
+          path: existingSecret
+          value: "service-reg-secret"
+
+  - it: ignores the existingSecret when the internal registry is enabled
+    set:
+      registry:
+        existingSecret: "service-reg-secret"
+      global:
+        registry:
+          enabled: true
+          existingSecret: "global-reg-secret"
+    asserts:
+      - equal:
+          path: existingSecret
+          value: ""

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.5.0-rc.2
+  version: 2.5.0-rc.3
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
   version: 2.5.0-rc.1
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:aae86f94b78398ee5c91a580e4d71163e0585762efb949997f9f734dbd7ef6b1
-generated: "2026-09-11T12:29:52.642959+08:00"
+digest: sha256:df57a86accba1fe4fb0b4e048ac72c11f73b1f23f68911d7a65cd8fbf02639c9
+generated: "2026-09-11T14:17:03.456986+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0-rc.3
+version: 2.5.0-rc.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -52,7 +52,7 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.5.0-rc.2
+    version: 2.5.0-rc.3
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -213,6 +213,7 @@ portal:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_portal"            # Database name
@@ -223,6 +224,7 @@ portal:
 
   ## Object storage configuration
   objectStore: {}
+    # existingSecret: ""                   # Overrides the global objectStore.existingSecret when set
     # endpoint: ""                         # Object storage endpoint URL
     # accessKey: ""                        # Access key for authentication
     # secretKey: ""                        # Secret key for authentication
@@ -291,6 +293,7 @@ server:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_server"            # Database name
@@ -301,12 +304,14 @@ server:
 
   ## Redis configuration
   redis: {}
+    # existingSecret: ""                   # Overrides the global redis.existingSecret when set
     # host: "<redis_host>"                 # Redis server hostname or IP
     # port: 6379                           # Redis port number
     # password: ""                         # Redis authentication password
 
   ## Object storage configuration
   objectStore: {}
+    # existingSecret: ""                   # Overrides the global objectStore.existingSecret when set
     # endpoint: ""                         # Object storage endpoint URL
     # accessKey: ""                        # Access key for authentication
     # secretKey: ""                        # Secret key for authentication
@@ -421,6 +426,7 @@ xnet:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_xnet"              # Database name
@@ -431,12 +437,14 @@ xnet:
 
   ## Redis configuration
   redis: {}
+    # existingSecret: ""                   # Overrides the global redis.existingSecret when set
     # host: "<redis_host>"                 # Redis server hostname or IP
     # port: 6379                           # Redis port number
     # password: ""                         # Redis authentication password
 
   ## Object storage configuration
   objectStore: {}
+    # existingSecret: ""                   # Overrides the global objectStore.existingSecret when set
     # endpoint: ""                         # Object storage endpoint URL
     # accessKey: ""                        # Access key for authentication
     # secretKey: ""                        # Secret key for authentication
@@ -714,7 +722,8 @@ registry:
     formatter: "json"                        # Log format: json, text, logstash
     accesslog: true                          # Enable access log
 
-  objectStore: {}                            # External object storage
+  objectStore: {}
+    # existingSecret: ""                     # Overrides the global objectStore.existingSecret when set
     # endpoint: ""                           # Object storage endpoint URL
     # accessKey: ""                          # Access key for authentication
     # secretKey: ""                          # Secret key for authentication
@@ -812,7 +821,8 @@ casdoor:
       # enabled: false                       # Enable or disable TLS
       # secretName: ""                       # TLS secret name
 
-  postgresql: {}                             # Database configuration
+  postgresql: {}
+    # existingSecret: ""                     # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                      # PostgreSQL host address
     # port: 5432                             # PostgreSQL port
     # database: "csghub_casdoor"             # Database name
@@ -850,7 +860,8 @@ temporal:
       # enabled: false                       # Enable or disable TLS
       # secretName: ""                       # TLS secret name
 
-  postgresql: {}                             # Database configuration
+  postgresql: {}
+    # existingSecret: ""                     # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                      # PostgreSQL host address
     # port: 5432                             # PostgreSQL port
     # database: "csghub_temporal"            # Database name

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -134,6 +134,9 @@ global:
       # username: ""                # Registry username
       # password: ""                # Registry password
       # insecure: false           # Disable TLS/SSL encryption
+    ## Reference an existing Secret containing REGISTRY_HOST/[REGISTRY_REPOSITORY]/
+    ## [REGISTRY_USERNAME]/[REGISTRY_PASSWORD]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## Gitaly configuration
   gitaly:

--- a/charts/csgship/values.yaml
+++ b/charts/csgship/values.yaml
@@ -135,6 +135,7 @@ web:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csgship_csgship"          # Database name
@@ -145,6 +146,7 @@ web:
 
   ## Redis configuration
   redis: {}
+    # existingSecret: ""                   # Overrides the global redis.existingSecret when set
     # host: "<redis_host>"                 # Redis server hostname or IP
     # port: 6379                           # Redis port number
     # password: ""                         # Redis authentication password
@@ -276,7 +278,8 @@ casdoor:
       # enabled: false                       # Enable or disable TLS
       # secretName: ""                       # TLS secret name
 
-  postgresql: {}                             # Database configuration
+  postgresql: {}
+    # existingSecret: ""                     # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                      # PostgreSQL host address
     # port: 5432                             # PostgreSQL port
     # database: "csghub_casdoor"             # Database name

--- a/charts/dataflow/values.yaml
+++ b/charts/dataflow/values.yaml
@@ -104,6 +104,7 @@ dataflow:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_dataflow"          # Database name
@@ -140,6 +141,7 @@ labelStudio:
 
   ## Database configuration
   postgresql: {}
+    # existingSecret: ""                   # Overrides the global postgresql.existingSecret when set
     # host: "<pg_host>"                    # PostgreSQL host address
     # port: 5432                           # PostgreSQL port
     # database: "csghub_label_studio"      # Database name

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.3.1
+  version: 0.3.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.5.4
-digest: sha256:58fbd4da84fea169818ff35ca4214cee5e07bea88acf5af34ee8be9f206e8b59
-generated: "2026-09-10T03:50:49.525372+08:00"
+digest: sha256:07e32717928dda9c32e2be509938ad3e2259cc850a1a65638365fd4284310192
+generated: "2026-09-11T14:07:04.661882+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.0-rc.2
+version: 2.5.0-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -36,7 +36,7 @@ appVersion: v2.5.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.3.1
+    version: 0.3.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -220,6 +220,8 @@ registry: {}
   # username: ""                           # Registry username
   # password: ""                           # Registry password
   # insecure: false                        # Disable TLS/SSL encryption
+  # existingSecret: ""                     # Secret with REGISTRY_HOST/[REGISTRY_USERNAME]/[REGISTRY_PASSWORD];
+                                           # It overrides global.registry.existingSecret
 
 ## ObjectStore Configuration
 objectStore: {}                            # External object storage

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -55,10 +55,17 @@ global:
   ## Disable internal Registry (It's Only a flag)
   registry:
     enabled: false
+    ## Reference an existing Secret containing REGISTRY_HOST/[REGISTRY_REPOSITORY]/
+    ## [REGISTRY_USERNAME]/[REGISTRY_PASSWORD]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## Disable internal ObjectStore (It's Only a flag)
   objectStore:
     enabled: false
+    ## Reference an existing Secret containing OBJECT_STORE_ENDPOINT/
+    ## OBJECT_STORE_ACCESS_KEY/OBJECT_STORE_SECRET_KEY/[OBJECT_STORE_REGION]/
+    ## [OBJECT_STORE_BUCKET]. Only honored when enabled=false.
+    existingSecret: ""
 
   ## SubChart deployment context
   chartContext:
@@ -215,16 +222,22 @@ tempo:
 
 ## Registry Configuration
 registry: {}
+  ## Reference an existing Secret containing REGISTRY_HOST/[REGISTRY_REPOSITORY]/
+  ## [REGISTRY_USERNAME]/[REGISTRY_PASSWORD]. Overrides the global
+  ## registry.existingSecret when set. Only honored when enabled=false.
+  # existingSecret: ""
   # registry: ""                           # External registry URL
   # repository: "csghub"                   # Repository namespace
   # username: ""                           # Registry username
   # password: ""                           # Registry password
   # insecure: false                        # Disable TLS/SSL encryption
-  # existingSecret: ""                     # Secret with REGISTRY_HOST/[REGISTRY_USERNAME]/[REGISTRY_PASSWORD];
-                                           # It overrides global.registry.existingSecret
 
 ## ObjectStore Configuration
-objectStore: {}                            # External object storage
+objectStore: {}
+  ## Reference an existing Secret containing OBJECT_STORE_ENDPOINT/OBJECT_STORE_ACCESS_KEY/
+  ## OBJECT_STORE_SECRET_KEY/[OBJECT_STORE_REGION]/[OBJECT_STORE_BUCKET]. Overrides the
+  ## global objectStore.existingSecret when set. Only honored when enabled=false.
+  # existingSecret: ""
   # endpoint: ""                           # Object storage endpoint URL
   # accessKey: ""                          # Access key for authentication
   # secretKey: ""                          # Secret key for authentication


### PR DESCRIPTION
## Summary

The container registry was the only connection type missing `existingSecret`: postgresql/redis/gitaly/objectStore already had it. Also, although the helper already supported per-service `existingSecret` overrides, `values.yaml` did not expose them. This PR fills both gaps.

## Changes

**common**

- New `common.registry.existingSecret` name-resolution helper: service-level `registry.existingSecret` > `global.registry.existingSecret`, and only effective when `global.registry.enabled=false`.
- `common.registry.config` reads connection info from the referenced Secret via `lookup`: `REGISTRY_HOST` (required) plus optional `REGISTRY_REPOSITORY`/`REGISTRY_USERNAME`/`REGISTRY_PASSWORD`. Falls back to the configured external values when the Secret is missing or has no `REGISTRY_HOST`.
- Tests: new `registry-existing-secret_test.yaml` for resolution precedence, plus a fallback case in `registry-config_test.yaml` for a missing Secret.

**values.yaml**

- Added `# existingSecret: ""` placeholders (with the supported Secret keys) to the service-level empty blocks across charts: csghub (portal/server/xnet/registry/casdoor/temporal), runner, csgship (web/casdoor), dataflow (dataflow/labelStudio), agentichub (agenticflow).
- runner: expose `existingSecret` for global `registry`/`objectStore`; add placeholders for the service-level `registry`/`objectStore`.

**charts**

- csghub `2.5.0-rc.4`, runner `2.5.0-rc.3` (including Chart.lock).

## Test plan

- [x] `bash scripts/test-common.sh` — 22/22
- [x] `helm unittest charts/runner --with-subchart=false` — 147/147
- [x] `helm unittest charts/csghub --with-subchart=false` — 410/410
- [x] `helm unittest charts/{dataflow,csgship,agentichub} --with-subchart=false` — all green
- [x] Real cluster (`--dry-run=server`): Secret present -> injected; Secret missing -> fallback; `enabled=true` -> Secret ignored; service-level overrides global
