### PR TITLE
feat(csghub): make loki gatewayAuth.htpasswd optional to allow no-aut…

### DIFF
--- a/charts/csghub/templates/loki/secret.yaml
+++ b/charts/csghub/templates/loki/secret.yaml
@@ -17,5 +17,5 @@ metadata:
 type: Opaque
 data:
   {{- $defaultHtpasswd := $service.gatewayAuth.htpasswd }}
-  .htpasswd: {{ $defaultHtpasswd | required "loki.gatewayAuth.htpasswd is required" | b64enc | quote }}
+  .htpasswd: {{ $defaultHtpasswd | b64enc | quote }}
 {{- end }}

--- a/charts/csghub/templates/loki/securitypolicy.yaml
+++ b/charts/csghub/templates/loki/securitypolicy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "loki") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if and $service.gatewayAuth.enabled (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
+{{- if and $service.gatewayAuth.enabled $service.gatewayAuth.htpasswd (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:

--- a/charts/csghub/tests/loki-secret_test.yaml
+++ b/charts/csghub/tests/loki-secret_test.yaml
@@ -18,6 +18,16 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: renders nothing when enabled without a configured htpasswd
+    template: loki/secret.yaml
+    set:
+      loki:
+        gatewayAuth:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: encodes the configured htpasswd
     template: loki/secret.yaml
     set:

--- a/charts/csghub/tests/loki-securitypolicy_test.yaml
+++ b/charts/csghub/tests/loki-securitypolicy_test.yaml
@@ -24,6 +24,7 @@ tests:
       loki:
         gatewayAuth:
           enabled: true
+          htpasswd: "loki:$2y$10$abcdefghijklmnopqrstuvwx"
     asserts:
       - isKind:
           of: SecurityPolicy
@@ -52,12 +53,23 @@ tests:
           path: spec.basicAuth.forwardUsernameHeader
           value: "X-Forwarded-User"
 
+  - it: renders nothing when no htpasswd is configured
+    template: loki/securitypolicy.yaml
+    set:
+      loki:
+        gatewayAuth:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders nothing for a non-envoyproxy controller
     template: loki/securitypolicy.yaml
     set:
       loki:
         gatewayAuth:
           enabled: true
+          htpasswd: "loki:$2y$10$abcdefghijklmnopqrstuvwx"
       global:
         gateway:
           controllerName: istio.io/gateway-controller

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -885,7 +885,7 @@ reloader:
 loki:
   gatewayAuth:
     enabled: false                         # Enable Gateway BasicAuth for Loki
-    # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
+    # htpasswd: ""                         # Optional; omit to expose without auth. Generate: htpasswd -nbs <username> <password>
 
   gateway:
     enabled: false                         # Disable loki internal gateway default


### PR DESCRIPTION
## Summary
- Make `loki.gatewayAuth.htpasswd` optional. With `gatewayAuth.enabled=true` and no `htpasswd`, Loki is exposed through the Gateway without BasicAuth.
- Previously the two templates disagreed: the Secret was gated on `htpasswd` being set, but the SecurityPolicy was gated only on `enabled`. Enabling auth without an htpasswd therefore rendered a `basicAuth` SecurityPolicy pointing at a Secret that was never created.

## Changes
- `templates/loki/securitypolicy.yaml`: gate the `basicAuth` SecurityPolicy on `htpasswd` being set (in addition to `enabled` and the envoyproxy controller check).
- `templates/loki/secret.yaml`: drop the `required "loki.gatewayAuth.htpasswd is required"` guard — the document already renders only when `htpasswd` is set.
- `values.yaml`: document `htpasswd` as optional.
- Tests: cover the enabled-without-htpasswd path for both the Secret and the SecurityPolicy.

## Behavior
| `enabled` | `htpasswd` | HTTPRoute | SecurityPolicy | Secret |
|---|---|---|---|---|
| true  | set   | yes | yes (basicAuth) | yes |
| true  | unset | yes | no              | no  |
| false | any   | no  | no              | yes (if set) |

The HTTPRoute gate is unchanged (still `enabled`); only the auth layer is dropped when no htpasswd is configured.

## Notes
- Prometheus has identical `gatewayAuth` templates and is intentionally left untouched here; the same treatment can be applied there separately.
- Generate an htpasswd entry with `htpasswd -nbs <username> <password>`.

## Test plan
- [x] `helm unittest charts/csghub --with-subchart=false` — 412/412 pass
- [x] Rendered with `enabled=true` both with and without `htpasswd` to confirm SecurityPolicy/Secret presence