### PR TITLE
fix(common): prefer global registry over local in common.image.fixed

### DIFF
--- a/charts/common/templates/_image.tpl
+++ b/charts/common/templates/_image.tpl
@@ -117,7 +117,7 @@ Returns: Full image path in format "registry/repository"
     {{- $localImage = $ctx.Values.image }}
   {{- end }}
 
-  {{- $registry := or $localImage.registry $globalImage.registry }}
+  {{- $registry := or $globalImage.registry $localImage.registry }}
   {{- if eq $globalImage.registryPolicy "force" }}
     {{- $registry = or $globalImage.registry "registry.opencsg.com" }}
   {{- end }}


### PR DESCRIPTION
## Summary
`common.image.fixed` (used for utility images — busybox, psql, agenticflow-importer — in the `wait-for-*` init containers and in migration/importer Job containers) resolved the registry as:

```
or $localImage.registry $globalImage.registry
```

So a service-level or chart top-level `image.registry` silently overrode `global.image.registry`. Concretely, when `global.image.registry=registry.opencsg.com` was set but the chart's top-level `image.registry` was `docker.io`, the utility images still pulled from `docker.io` — the registry.opencsg.com switch never applied to them.

## Change
One line in `charts/common/templates/_image.tpl`: flip the precedence so the global registry wins and the local one is only a fallback.

```diff
-{{- $registry := or $localImage.registry $globalImage.registry }}
+{{- $registry := or $globalImage.registry $localImage.registry }}
```

`registryPolicy: force` handling is unchanged (it still hard-overrides both).

## Behavior
| `global.image.registry` | local `image.registry` | rendered image |
|---|---|---|
| registry.opencsg.com | — | `registry.opencsg.com/opencsghq/busybox:latest` |
| registry.opencsg.com | `my-private.io` | `registry.opencsg.com/opencsghq/busybox:latest` (was `my-private.io/busybox:latest`) |
| docker.io | registry.opencsg.com | `docker.io/busybox:latest` (was `registry.opencsg.com/opencsghq/busybox:latest`) |

The local registry is still honored when no global registry is set, so existing deployments that only set a local registry are unaffected.

## Notes
- No application container image is affected — `common.image.fixed` is used exclusively for utility images (init containers and Job containers), never for a service's own image. `common.image` (the app-image helper) is untouched.
- Takes effect only after `common` is republished and the dependent charts (runner/dataflow/csgship/agentichub/csghub) re-pin the new version.

## Test plan
- [x] `scripts/test-common.sh` — 22/22 pass
- [x] `helm unittest` for runner (147), dataflow (143), csgship (193), agentichub (191), csghub (412) — all pass
- [x] Behavior verified by swapping a locally-packaged `common` into the dependent charts and rendering with the table above's inputs