### PR TITLE
feat(values): set Recreate strategy for PVC-backed deployments

### DIFF
--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -164,6 +164,10 @@ agenticflow:
     accessModes: ["ReadWriteOnce"]         # Volume access permissions
     size: "20Gi"                           # Disk space allocation
 
+  ## Deployment strategy
+  strategy:
+    type: Recreate                         # Recreate avoids RWO PVC conflicts
+
   resources:
     requests:
       cpu: "500m"
@@ -178,6 +182,10 @@ csgbot:
     # storageClass: ""                     # StorageClass for dynamic provisioning
     # accessModes: ["ReadWriteOnce"]       # Volume access permissions
     size: "20Gi"                           # Disk space allocation
+
+  ## Deployment strategy
+  strategy:
+    type: Recreate                         # Recreate avoids RWO PVC conflicts
 
   image:
     # registry: "docker.io"

--- a/charts/dataflow/values.yaml
+++ b/charts/dataflow/values.yaml
@@ -118,6 +118,10 @@ dataflow:
     accessModes: ["ReadWriteOnce"]           # Volume access permissions
     size: "50Gi"                             # Disk space allocation
 
+  ## Deployment strategy
+  strategy:
+    type: Recreate                           # Recreate avoids RWO PVC conflicts
+
   ## Table rename migration
   migrations:
     enabled: true


### PR DESCRIPTION
Set `strategy.type: Recreate` for PVC-backed Deployments (agentichub/agenticflow, agentichub/csgbot, dataflow) to avoid `FailedAttachVolume` during rollouts.

**Why**

These workloads mount `ReadWriteOnce` PVCs. With the default `RollingUpdate`, a new pod can be created before the previous one releases the RWO volume; on single-replica Deployments (the default for these services) the new pod has nowhere else to land and the attach fails. `Recreate` scales the old pod to zero before starting the new one, so the PVC is detached first.

**New values keys** (overridable per service):

- `agenticflow.strategy.type`
- `csgbot.strategy.type`
- `dataflow.strategy.type`

Default is `Recreate`. Set to `RollingUpdate` only if you intentionally run multi-replica and can tolerate the brief downtime.